### PR TITLE
Empty input yields empty node rather than error.

### DIFF
--- a/lib/empty.js
+++ b/lib/empty.js
@@ -1,0 +1,11 @@
+var Node = require('./node');
+var NodeTypes = require('./node-types');
+
+module.exports = function() {
+  return new Node({
+      type: NodeTypes.SType,
+      content: '',
+      start: [0, 0],
+      end: [0, 0]
+  });
+};

--- a/lib/empty.js
+++ b/lib/empty.js
@@ -3,7 +3,7 @@ var NodeTypes = require('./node-types');
 
 module.exports = function() {
   return new Node({
-      type: NodeTypes.SType,
+      type: NodeTypes.StylesheetType,
       content: '',
       start: [0, 0],
       end: [0, 0]

--- a/lib/empty.js
+++ b/lib/empty.js
@@ -4,7 +4,7 @@ var NodeTypes = require('./node-types');
 module.exports = function() {
   return new Node({
       type: NodeTypes.StylesheetType,
-      content: '',
+      content: [],
       start: [0, 0],
       end: [0, 0]
   });

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -14,8 +14,10 @@ var Defaults = {
  * @return {Object} AST
  */
 function parse(css, options) {
-    if (!css || typeof css !== 'string')
+    if (typeof css !== 'string')
         throw new Error('Please, pass a string to parse');
+    else if (!css) 
+        return require('./empty')();
 
     var syntax = options && options.syntax || Defaults.SYNTAX;
     var needInfo = options && options.needInfo || Defaults.NEED_INFO;

--- a/test/empty.js
+++ b/test/empty.js
@@ -1,0 +1,15 @@
+var assert = require('assert');
+var gonzales = require('../');
+var NodeTypes = require('../lib/node-types');
+
+describe('Empty input', function() {
+    it('should return space type', function() {
+        var ast = gonzales.parse('');
+        assert.equal(ast.type, NodeTypes.SType);
+    });
+
+    it('should return empty content', function() {
+        var ast = gonzales.parse('');
+        assert.equal(ast.content, '');
+    });
+});

--- a/test/empty.js
+++ b/test/empty.js
@@ -10,6 +10,6 @@ describe('Empty input', function() {
 
     it('should return empty content', function() {
         var ast = gonzales.parse('');
-        assert.equal(ast.content, '');
+        assert.equal(ast.content.length, 0);
     });
 });

--- a/test/empty.js
+++ b/test/empty.js
@@ -3,9 +3,9 @@ var gonzales = require('../');
 var NodeTypes = require('../lib/node-types');
 
 describe('Empty input', function() {
-    it('should return space type', function() {
+    it('should return stylesheet type', function() {
         var ast = gonzales.parse('');
-        assert.equal(ast.type, NodeTypes.SType);
+        assert.equal(ast.type, NodeTypes.StylesheetType);
     });
 
     it('should return empty content', function() {

--- a/test/mocha.js
+++ b/test/mocha.js
@@ -5,6 +5,7 @@ mocha.reporter('dot');
 require('./parser')(mocha);
 mocha.addFile('test/parsing-error');
 mocha.addFile('test/node');
+mocha.addFile('test/empty');
 
 mocha.run(function(failures) {
     process.on('exit', function() {


### PR DESCRIPTION
Fix for #71. Should now have latest dev branch.
