### PR TITLE
[api] client side Javascript support

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,24 @@ npm install
 npm run init
 ```
 
+### Client-side Javascript (UMD modules)
+
+Running :
+
+```npm run web-build```
+
+will generate multiple files in a ```dist``` folder. They are UMD modules 
+that can be loaded in a client-side script. However, to reduce file sizes for 
+those who just need a specific syntax for the parser, there is one file per syntax.
+
+To add a syntax to the parser (ie. less) your script should start with : 
+
+```
+var gonzales = require("gonzales-core");
+
+require("gonzales-less")(gonzales);
+```
+
 ## API
 
 Basically there are a few things you can do:

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "build": "./scripts/build.sh",
     "init": "./scripts/init.sh",
     "log": "./scripts/log.sh",
-    "test": "./scripts/build.sh && ./scripts/test.sh"
+    "test": "./scripts/build.sh && ./scripts/test.sh",
+    "web-build": "./scripts/web-build.sh"
   },
   "bin": {
     "gonzales": "./bin/gonzales.js"
@@ -37,7 +38,10 @@
     "coffee-script": "~1.7.1",
     "jscs": "2.1.0",
     "jshint": "2.8.0",
-    "mocha": "2.2.x"
+    "json-loader": "^0.5.3",
+    "mocha": "2.2.x",
+    "null-loader": "^0.1.1",
+    "webpack": "^1.12.2"
   },
   "engines": {
     "node": ">=0.6.0"

--- a/scripts/web-build.sh
+++ b/scripts/web-build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+./scripts/build.sh
+
+mkdir -p dist
+
+set -e -u
+echo "Generating webpack modules"
+
+webpack --module-bind "json=json" --module-bind "node.js=null" --define IS_WEBPACK=true --output-library-target umd lib/gonzales.js dist/gonzales.core.js
+webpack --module-bind "json=json" --define IS_WEBPACK=true --output-library-target umd lib/css/index.js dist/gonzales.css.js
+webpack --module-bind "json=json" --define IS_WEBPACK=true --output-library-target umd lib/less/index.js dist/gonzales.less.js
+webpack --module-bind "json=json" --define IS_WEBPACK=true --output-library-target umd lib/sass/index.js dist/gonzales.sass.js
+webpack --module-bind "json=json" --define IS_WEBPACK=true --output-library-target umd lib/scss/index.js dist/gonzales.scss.js

--- a/src/css/index.js
+++ b/src/css/index.js
@@ -1,0 +1,10 @@
+'use strict';
+
+export default function moduleDef(gonzalesInstance) {
+  return gonzalesInstance.registerSyntax({
+    mark: require('./mark'),
+    parse: require('./parse'),
+    stringify: require('./stringify'),
+    tokenizer: require('./tokenizer')
+  }, 'css');
+}

--- a/src/get-syntax.node.js
+++ b/src/get-syntax.node.js
@@ -1,0 +1,6 @@
+'use strict';
+
+export default function(syntax, gonzalesInstance) {
+  const path = `${__dirname}/${syntax}`;
+  return require(path)(gonzalesInstance);
+}

--- a/src/gonzales.js
+++ b/src/gonzales.js
@@ -3,9 +3,25 @@
 var Node = require('./node/basic-node');
 var parse = require('./parse');
 
-module.exports = {
+global.registeredSyntaxes = {};
+
+var exports = {
   createNode: function(options) {
     return new Node(options);
   },
-  parse: parse
+  registerSyntax : function(objects, type) {
+    global.registeredSyntaxes[type] = objects;
+    return objects;
+  },
+  getSyntax: function(type) {
+    if (global.registeredSyntaxes[type] !== undefined) {
+      return global.registeredSyntaxes[type];
+    } else {
+      return null;
+    }
+  }
 };
+
+exports.parse = parse.bind(null, exports);
+
+module.exports = exports;

--- a/src/less/index.js
+++ b/src/less/index.js
@@ -1,0 +1,10 @@
+'use strict';
+
+export default function moduleDef(gonzalesInstance) {
+  return gonzalesInstance.registerSyntax({
+    mark: require('./mark'),
+    parse: require('./parse'),
+    stringify: require('./stringify'),
+    tokenizer: require('./tokenizer')
+  }, 'less');
+}

--- a/src/node/basic-node.js
+++ b/src/node/basic-node.js
@@ -162,7 +162,7 @@ class Node {
       let stringify;
 
       try {
-        stringify = require('../' + this.syntax + '/stringify');
+        stringify = global.registeredSyntaxes[this.syntax].stringify;
       } catch (e) {
         var message = `Syntax "${this.syntax}" is not supported yet, sorry`;
         return console.error(message);

--- a/src/sass/index.js
+++ b/src/sass/index.js
@@ -1,0 +1,10 @@
+'use strict';
+
+export default function moduleDef(gonzalesInstance) {
+  return gonzalesInstance.registerSyntax({
+    mark: require('./mark'),
+    parse: require('./parse'),
+    stringify: require('./stringify'),
+    tokenizer: require('./tokenizer')
+  }, 'sass');
+}

--- a/src/scss/index.js
+++ b/src/scss/index.js
@@ -1,0 +1,10 @@
+'use strict';
+
+export default function moduleDef(gonzalesInstance) {
+  return gonzalesInstance.registerSyntax({
+    mark: require('./mark'),
+    parse: require('./parse'),
+    stringify: require('./stringify'),
+    tokenizer: require('./tokenizer')
+  }, 'scss');
+}


### PR DESCRIPTION
Hi,

I've added a script and made some changes to the library to allow compilation for client side Javascript. I had to : 
- Add another way to add syntax modules to the library (conditional requires are not supported when compiling through Webpack) ;
- Add a specific file for syntax inclusion (`get-syntax.node.js` - this file is only read by NodeJS but is ignore by Webpack) ;
- Add an index to each module to ease the import process ;

I also added a paragraph in the README for those who are interested in compiling these files.

Tests are passing. I haven't found a way to make it easier (ie. changing less files) but it works and it does not change the way the library works for NodeJS.
