### PR TITLE
Sass - Stop extend showing as atrule

### DIFF
--- a/src/sass/parse.js
+++ b/src/sass/parse.js
@@ -653,7 +653,7 @@ function checkBlockdecl1(i) {
       [2, 4, 6, 8].indexOf(tokens[start].include_type) === -1) return 0;
 
   if (tokens[start].bd_kind === 6 &&
-      tokens[start].atrule_type !== 3) return 0;
+      tokens[start].atrule_type === 3) return 0;
 
   while (i < tokensLength) {
     if (l = checkDeclDelim(i))

--- a/test/sass/stylesheet/issue-147-1.json
+++ b/test/sass/stylesheet/issue-147-1.json
@@ -1,0 +1,420 @@
+{
+  "type": "stylesheet",
+  "content": [
+    {
+      "type": "ruleset",
+      "content": [
+        {
+          "type": "selector",
+          "content": [
+            {
+              "type": "class",
+              "content": [
+                {
+                  "type": "ident",
+                  "content": "foo",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 1,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 4
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 1,
+                "column": 1
+              },
+              "end": {
+                "line": 1,
+                "column": 4
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 1,
+            "column": 4
+          }
+        },
+        {
+          "type": "space",
+          "content": "\n",
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 5
+          },
+          "end": {
+            "line": 1,
+            "column": 5
+          }
+        },
+        {
+          "type": "block",
+          "content": [
+            {
+              "type": "space",
+              "content": "  ",
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 1
+              },
+              "end": {
+                "line": 2,
+                "column": 2
+              }
+            },
+            {
+              "type": "extend",
+              "content": [
+                {
+                  "type": "atkeyword",
+                  "content": [
+                    {
+                      "type": "ident",
+                      "content": "extend",
+                      "syntax": "sass",
+                      "start": {
+                        "line": 2,
+                        "column": 4
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 9
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 9
+                  }
+                },
+                {
+                  "type": "space",
+                  "content": " ",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 10
+                  }
+                },
+                {
+                  "type": "selector",
+                  "content": [
+                    {
+                      "type": "placeholder",
+                      "content": [
+                        {
+                          "type": "ident",
+                          "content": "foo",
+                          "syntax": "sass",
+                          "start": {
+                            "line": 2,
+                            "column": 12
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 14
+                          }
+                        }
+                      ],
+                      "syntax": "sass",
+                      "start": {
+                        "line": 2,
+                        "column": 11
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 14
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 14
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 2,
+                "column": 14
+              }
+            },
+            {
+              "type": "space",
+              "content": "\n",
+              "syntax": "sass",
+              "end": {
+                "line": 2,
+                "column": 15
+              },
+              "start": {
+                "column": 15,
+                "line": 2
+              }
+            },
+            {
+              "type": "space",
+              "syntax": "sass",
+              "content": "\n",
+              "start": {
+                "column": 1,
+                "line": 3
+              },
+              "end": {
+                "column": 1,
+                "line": 3
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 2,
+            "column": 1
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    },
+    {
+      "type": "ruleset",
+      "content": [
+        {
+          "type": "selector",
+          "content": [
+            {
+              "type": "class",
+              "content": [
+                {
+                  "type": "ident",
+                  "content": "bar",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 4,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 4
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 4,
+                "column": 1
+              },
+              "end": {
+                "line": 4,
+                "column": 4
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 4,
+            "column": 1
+          },
+          "end": {
+            "line": 4,
+            "column": 4
+          }
+        },
+        {
+          "type": "space",
+          "content": "\n",
+          "syntax": "sass",
+          "start": {
+            "line": 4,
+            "column": 5
+          },
+          "end": {
+            "line": 4,
+            "column": 5
+          }
+        },
+        {
+          "type": "block",
+          "content": [
+            {
+              "type": "space",
+              "content": "  ",
+              "syntax": "sass",
+              "start": {
+                "line": 5,
+                "column": 1
+              },
+              "end": {
+                "line": 5,
+                "column": 2
+              }
+            },
+            {
+              "type": "extend",
+              "content": [
+                {
+                  "type": "atkeyword",
+                  "content": [
+                    {
+                      "type": "ident",
+                      "content": "extend",
+                      "syntax": "sass",
+                      "start": {
+                        "line": 5,
+                        "column": 4
+                      },
+                      "end": {
+                        "line": 5,
+                        "column": 9
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 5,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 9
+                  }
+                },
+                {
+                  "type": "space",
+                  "content": " ",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 5,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 10
+                  }
+                },
+                {
+                  "type": "selector",
+                  "content": [
+                    {
+                      "type": "placeholder",
+                      "content": [
+                        {
+                          "type": "ident",
+                          "content": "bar",
+                          "syntax": "sass",
+                          "start": {
+                            "line": 5,
+                            "column": 12
+                          },
+                          "end": {
+                            "line": 5,
+                            "column": 14
+                          }
+                        }
+                      ],
+                      "syntax": "sass",
+                      "start": {
+                        "line": 5,
+                        "column": 11
+                      },
+                      "end": {
+                        "line": 5,
+                        "column": 14
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 5,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 14
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 5,
+                "column": 3
+              },
+              "end": {
+                "line": 5,
+                "column": 14
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 5,
+            "column": 1
+          },
+          "end": {
+            "line": 5,
+            "column": 14
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 4,
+        "column": 1
+      },
+      "end": {
+        "line": 5,
+        "column": 14
+      }
+    }
+  ],
+  "syntax": "sass",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 5,
+    "column": 14
+  }
+}

--- a/test/sass/stylesheet/issue-147-1.sass
+++ b/test/sass/stylesheet/issue-147-1.sass
@@ -1,0 +1,5 @@
+.foo
+  @extend %foo
+
+.bar
+  @extend %bar

--- a/test/sass/stylesheet/issue-147-2.json
+++ b/test/sass/stylesheet/issue-147-2.json
@@ -1,0 +1,204 @@
+{
+  "type": "stylesheet",
+  "content": [
+    {
+      "type": "ruleset",
+      "content": [
+        {
+          "type": "selector",
+          "content": [
+            {
+              "type": "class",
+              "content": [
+                {
+                  "type": "ident",
+                  "content": "foo",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 1,
+                    "column": 2
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 4
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 1,
+                "column": 1
+              },
+              "end": {
+                "line": 1,
+                "column": 4
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 1,
+            "column": 4
+          }
+        },
+        {
+          "type": "space",
+          "content": "\n",
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 5
+          },
+          "end": {
+            "line": 1,
+            "column": 5
+          }
+        },
+        {
+          "type": "block",
+          "content": [
+            {
+              "type": "space",
+              "content": "  ",
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 1
+              },
+              "end": {
+                "line": 2,
+                "column": 2
+              }
+            },
+            {
+              "type": "extend",
+              "content": [
+                {
+                  "type": "atkeyword",
+                  "content": [
+                    {
+                      "type": "ident",
+                      "content": "extend",
+                      "syntax": "sass",
+                      "start": {
+                        "line": 2,
+                        "column": 4
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 9
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 9
+                  }
+                },
+                {
+                  "type": "space",
+                  "content": " ",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 10
+                  }
+                },
+                {
+                  "type": "selector",
+                  "content": [
+                    {
+                      "type": "placeholder",
+                      "content": [
+                        {
+                          "type": "ident",
+                          "content": "foo",
+                          "syntax": "sass",
+                          "start": {
+                            "line": 2,
+                            "column": 12
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 14
+                          }
+                        }
+                      ],
+                      "syntax": "sass",
+                      "start": {
+                        "line": 2,
+                        "column": 11
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 14
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 14
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 2,
+                "column": 14
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 2,
+            "column": 1
+          },
+          "end": {
+            "line": 2,
+            "column": 14
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 2,
+        "column": 14
+      }
+    }
+  ],
+  "syntax": "sass",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 2,
+    "column": 14
+  }
+}

--- a/test/sass/stylesheet/issue-147-2.sass
+++ b/test/sass/stylesheet/issue-147-2.sass
@@ -1,0 +1,2 @@
+.foo
+  @extend %foo

--- a/test/sass/stylesheet/test.coffee
+++ b/test/sass/stylesheet/test.coffee
@@ -21,3 +21,6 @@ describe 'sass/stylesheet >>', ->
   it 's.1', -> this.shouldBeOk()
   it 's.2', -> this.shouldBeOk()
   it 's.3', -> this.shouldBeOk()
+
+  it 'issue-147-1', -> this.shouldBeOk()
+  it 'issue-147-2', -> this.shouldBeOk()


### PR DESCRIPTION
This PR fixes #147. As far as I could tell, the bug appears to be a typo? Also added some tests.
