### PR TITLE
WebPack: fix script with syntax entry point.

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ module.exports = {
   },
   output: {
     filename: syntax ? 'gonzales-' + syntax + '.js' : 'gonzales.js',
-    library: syntax ? 'gonzales-' + syntax : 'gonzales',
+    library: 'gonzales',
     libraryTarget: 'umd',
     path: __dirname + '/lib'
   },


### PR DESCRIPTION
Currently, the gonzales-scss.js assignes a parser to the
window["gonzales-scss"]. The patch makes it assign it to
window.gonzales.
