### PR TITLE
[SCSS | Sass] - Allow flags to be passed with arguments

### DIFF
--- a/src/sass/parse.js
+++ b/src/sass/parse.js
@@ -454,6 +454,9 @@ function checkArgument(i) {
   else if (l = checkUnary(i)) tokens[i].argument_child = 19;
   else if (l = checkParentSelector(i)) tokens[i].argument_child = 20;
   else if (l = checkImportant(i)) tokens[i].argument_child = 21;
+  else if (l = checkGlobal(i)) tokens[i].argument_child = 22;
+  else if (l = checkDefault(i)) tokens[i].argument_child = 23;
+  else if (l = checkOptional(i)) tokens[i].argument_child = 24;
 
   return l;
 }
@@ -485,6 +488,9 @@ function getArgument() {
   else if (childType === 19) return getUnary();
   else if (childType === 20) return getParentSelector();
   else if (childType === 21) return getImportant();
+  else if (childType === 22) return getGlobal();
+  else if (childType === 23) return getDefault();
+  else if (childType === 24) return getOptional();
 }
 
 /**

--- a/src/scss/parse.js
+++ b/src/scss/parse.js
@@ -417,6 +417,9 @@ function checkArgument(i) {
       checkOperator(i) ||
       checkUnary(i) ||
       checkImportant(i) ||
+      checkGlobal(i) ||
+      checkDefault(i) ||
+      checkOptional(i) ||
       checkParentSelector(i);
 }
 
@@ -444,6 +447,9 @@ function getArgument() {
   else if (checkOperator(pos)) return getOperator();
   else if (checkUnary(pos)) return getUnary();
   else if (checkImportant(pos)) return getImportant();
+  else if (checkGlobal(pos)) return getGlobal();
+  else if (checkDefault(pos)) return getDefault();
+  else if (checkOptional(pos)) return getOptional();
   else if (checkParentSelector(pos)) return getParentSelector();
 }
 

--- a/test/sass/arguments/flag.1.json
+++ b/test/sass/arguments/flag.1.json
@@ -1,0 +1,67 @@
+{
+  "type": "arguments",
+  "content": [
+    {
+      "type": "variable",
+      "content": [
+        {
+          "type": "ident",
+          "content": "foo",
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 3
+          },
+          "end": {
+            "line": 1,
+            "column": 5
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 2
+      },
+      "end": {
+        "line": 1,
+        "column": 5
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 6
+      },
+      "end": {
+        "line": 1,
+        "column": 6
+      }
+    },
+    {
+      "type": "important",
+      "content": "!important",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 7
+      },
+      "end": {
+        "line": 1,
+        "column": 16
+      }
+    }
+  ],
+  "syntax": "sass",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 1,
+    "column": 17
+  }
+}

--- a/test/sass/arguments/flag.1.sass
+++ b/test/sass/arguments/flag.1.sass
@@ -1,0 +1,1 @@
+($foo !important)

--- a/test/sass/arguments/flag.2.json
+++ b/test/sass/arguments/flag.2.json
@@ -1,0 +1,67 @@
+{
+  "type": "arguments",
+  "content": [
+    {
+      "type": "variable",
+      "content": [
+        {
+          "type": "ident",
+          "content": "foo",
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 3
+          },
+          "end": {
+            "line": 1,
+            "column": 5
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 2
+      },
+      "end": {
+        "line": 1,
+        "column": 5
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 6
+      },
+      "end": {
+        "line": 1,
+        "column": 6
+      }
+    },
+    {
+      "type": "optional",
+      "content": "!optional",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 7
+      },
+      "end": {
+        "line": 1,
+        "column": 15
+      }
+    }
+  ],
+  "syntax": "sass",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 1,
+    "column": 16
+  }
+}

--- a/test/sass/arguments/flag.2.sass
+++ b/test/sass/arguments/flag.2.sass
@@ -1,0 +1,1 @@
+($foo !optional)

--- a/test/sass/arguments/flag.3.json
+++ b/test/sass/arguments/flag.3.json
@@ -1,0 +1,67 @@
+{
+  "type": "arguments",
+  "content": [
+    {
+      "type": "variable",
+      "content": [
+        {
+          "type": "ident",
+          "content": "foo",
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 3
+          },
+          "end": {
+            "line": 1,
+            "column": 5
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 2
+      },
+      "end": {
+        "line": 1,
+        "column": 5
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 6
+      },
+      "end": {
+        "line": 1,
+        "column": 6
+      }
+    },
+    {
+      "type": "default",
+      "content": "!default",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 7
+      },
+      "end": {
+        "line": 1,
+        "column": 14
+      }
+    }
+  ],
+  "syntax": "sass",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 1,
+    "column": 15
+  }
+}

--- a/test/sass/arguments/flag.3.sass
+++ b/test/sass/arguments/flag.3.sass
@@ -1,0 +1,1 @@
+($foo !default)

--- a/test/sass/arguments/flag.4.json
+++ b/test/sass/arguments/flag.4.json
@@ -1,0 +1,67 @@
+{
+  "type": "arguments",
+  "content": [
+    {
+      "type": "variable",
+      "content": [
+        {
+          "type": "ident",
+          "content": "foo",
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 3
+          },
+          "end": {
+            "line": 1,
+            "column": 5
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 2
+      },
+      "end": {
+        "line": 1,
+        "column": 5
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 6
+      },
+      "end": {
+        "line": 1,
+        "column": 6
+      }
+    },
+    {
+      "type": "global",
+      "content": "!global",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 7
+      },
+      "end": {
+        "line": 1,
+        "column": 13
+      }
+    }
+  ],
+  "syntax": "sass",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 1,
+    "column": 14
+  }
+}

--- a/test/sass/arguments/flag.4.sass
+++ b/test/sass/arguments/flag.4.sass
@@ -1,0 +1,1 @@
+($foo !global)

--- a/test/sass/arguments/test.coffee
+++ b/test/sass/arguments/test.coffee
@@ -7,3 +7,8 @@ describe 'sass/arguments >>', ->
   it '4', -> this.shouldBeOk()
   it '5', -> this.shouldBeOk()
   it '6', -> this.shouldBeOk()
+
+  it 'flag.1', -> this.shouldBeOk()
+  it 'flag.2', -> this.shouldBeOk()
+  it 'flag.3', -> this.shouldBeOk()
+  it 'flag.4', -> this.shouldBeOk()

--- a/test/sass/include/11.json
+++ b/test/sass/include/11.json
@@ -1,0 +1,107 @@
+{
+  "type": "include",
+  "content": [
+    {
+      "type": "operator",
+      "content": "+",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 1,
+        "column": 1
+      }
+    },
+    {
+      "type": "ident",
+      "content": "nani",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 2
+      },
+      "end": {
+        "line": 1,
+        "column": 5
+      }
+    },
+    {
+      "type": "arguments",
+      "content": [
+        {
+          "type": "variable",
+          "content": [
+            {
+              "type": "ident",
+              "content": "foo",
+              "syntax": "sass",
+              "start": {
+                "line": 1,
+                "column": 8
+              },
+              "end": {
+                "line": 1,
+                "column": 10
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 7
+          },
+          "end": {
+            "line": 1,
+            "column": 10
+          }
+        },
+        {
+          "type": "space",
+          "content": " ",
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 11
+          },
+          "end": {
+            "line": 1,
+            "column": 11
+          }
+        },
+        {
+          "type": "important",
+          "content": "!important",
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 12
+          },
+          "end": {
+            "line": 1,
+            "column": 21
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 6
+      },
+      "end": {
+        "line": 1,
+        "column": 22
+      }
+    }
+  ],
+  "syntax": "sass",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 1,
+    "column": 22
+  }
+}

--- a/test/sass/include/11.sass
+++ b/test/sass/include/11.sass
@@ -1,0 +1,1 @@
++nani($foo !important)

--- a/test/sass/include/test.coffee
+++ b/test/sass/include/test.coffee
@@ -10,3 +10,4 @@ describe 'sass/include >>', ->
   it '8', -> this.shouldBeOk()
   it '9', -> this.shouldBeOk()
   it '10', -> this.shouldBeOk()
+  it '11', -> this.shouldBeOk()

--- a/test/scss/arguments/flag.1.json
+++ b/test/scss/arguments/flag.1.json
@@ -1,0 +1,67 @@
+{
+  "type": "arguments",
+  "content": [
+    {
+      "type": "variable",
+      "content": [
+        {
+          "type": "ident",
+          "content": "foo",
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 3
+          },
+          "end": {
+            "line": 1,
+            "column": 5
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 2
+      },
+      "end": {
+        "line": 1,
+        "column": 5
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 6
+      },
+      "end": {
+        "line": 1,
+        "column": 6
+      }
+    },
+    {
+      "type": "important",
+      "content": "!important",
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 7
+      },
+      "end": {
+        "line": 1,
+        "column": 16
+      }
+    }
+  ],
+  "syntax": "scss",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 1,
+    "column": 17
+  }
+}

--- a/test/scss/arguments/flag.1.scss
+++ b/test/scss/arguments/flag.1.scss
@@ -1,0 +1,1 @@
+($foo !important)

--- a/test/scss/arguments/flag.2.json
+++ b/test/scss/arguments/flag.2.json
@@ -1,0 +1,67 @@
+{
+  "type": "arguments",
+  "content": [
+    {
+      "type": "variable",
+      "content": [
+        {
+          "type": "ident",
+          "content": "foo",
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 3
+          },
+          "end": {
+            "line": 1,
+            "column": 5
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 2
+      },
+      "end": {
+        "line": 1,
+        "column": 5
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 6
+      },
+      "end": {
+        "line": 1,
+        "column": 6
+      }
+    },
+    {
+      "type": "optional",
+      "content": "!optional",
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 7
+      },
+      "end": {
+        "line": 1,
+        "column": 15
+      }
+    }
+  ],
+  "syntax": "scss",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 1,
+    "column": 16
+  }
+}

--- a/test/scss/arguments/flag.2.scss
+++ b/test/scss/arguments/flag.2.scss
@@ -1,0 +1,1 @@
+($foo !optional)

--- a/test/scss/arguments/flag.3.json
+++ b/test/scss/arguments/flag.3.json
@@ -1,0 +1,67 @@
+{
+  "type": "arguments",
+  "content": [
+    {
+      "type": "variable",
+      "content": [
+        {
+          "type": "ident",
+          "content": "foo",
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 3
+          },
+          "end": {
+            "line": 1,
+            "column": 5
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 2
+      },
+      "end": {
+        "line": 1,
+        "column": 5
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 6
+      },
+      "end": {
+        "line": 1,
+        "column": 6
+      }
+    },
+    {
+      "type": "default",
+      "content": "!default",
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 7
+      },
+      "end": {
+        "line": 1,
+        "column": 14
+      }
+    }
+  ],
+  "syntax": "scss",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 1,
+    "column": 15
+  }
+}

--- a/test/scss/arguments/flag.3.scss
+++ b/test/scss/arguments/flag.3.scss
@@ -1,0 +1,1 @@
+($foo !default)

--- a/test/scss/arguments/flag.4.json
+++ b/test/scss/arguments/flag.4.json
@@ -1,0 +1,67 @@
+{
+  "type": "arguments",
+  "content": [
+    {
+      "type": "variable",
+      "content": [
+        {
+          "type": "ident",
+          "content": "foo",
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 3
+          },
+          "end": {
+            "line": 1,
+            "column": 5
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 2
+      },
+      "end": {
+        "line": 1,
+        "column": 5
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 6
+      },
+      "end": {
+        "line": 1,
+        "column": 6
+      }
+    },
+    {
+      "type": "global",
+      "content": "!global",
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 7
+      },
+      "end": {
+        "line": 1,
+        "column": 13
+      }
+    }
+  ],
+  "syntax": "scss",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 1,
+    "column": 14
+  }
+}

--- a/test/scss/arguments/flag.4.scss
+++ b/test/scss/arguments/flag.4.scss
@@ -1,0 +1,1 @@
+($foo !global)

--- a/test/scss/arguments/test.coffee
+++ b/test/scss/arguments/test.coffee
@@ -9,3 +9,8 @@ describe 'scss/arguments >>', ->
   it '6', -> this.shouldBeOk()
   it '7', -> this.shouldBeOk()
   it '8', -> this.shouldBeOk()
+
+  it 'flag.1', -> this.shouldBeOk()
+  it 'flag.2', -> this.shouldBeOk()
+  it 'flag.3', -> this.shouldBeOk()
+  it 'flag.4', -> this.shouldBeOk()

--- a/test/scss/include/6.json
+++ b/test/scss/include/6.json
@@ -1,0 +1,134 @@
+{
+  "type": "include",
+  "content": [
+    {
+      "type": "atkeyword",
+      "content": [
+        {
+          "type": "ident",
+          "content": "include",
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 2
+          },
+          "end": {
+            "line": 1,
+            "column": 8
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 1,
+        "column": 8
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 9
+      },
+      "end": {
+        "line": 1,
+        "column": 9
+      }
+    },
+    {
+      "type": "ident",
+      "content": "nani",
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 10
+      },
+      "end": {
+        "line": 1,
+        "column": 13
+      }
+    },
+    {
+      "type": "arguments",
+      "content": [
+        {
+          "type": "variable",
+          "content": [
+            {
+              "type": "ident",
+              "content": "foo",
+              "syntax": "scss",
+              "start": {
+                "line": 1,
+                "column": 16
+              },
+              "end": {
+                "line": 1,
+                "column": 18
+              }
+            }
+          ],
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 15
+          },
+          "end": {
+            "line": 1,
+            "column": 18
+          }
+        },
+        {
+          "type": "space",
+          "content": " ",
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 19
+          },
+          "end": {
+            "line": 1,
+            "column": 19
+          }
+        },
+        {
+          "type": "important",
+          "content": "!important",
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 20
+          },
+          "end": {
+            "line": 1,
+            "column": 29
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 14
+      },
+      "end": {
+        "line": 1,
+        "column": 30
+      }
+    }
+  ],
+  "syntax": "scss",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 1,
+    "column": 30
+  }
+}

--- a/test/scss/include/6.scss
+++ b/test/scss/include/6.scss
@@ -1,0 +1,1 @@
+@include nani($foo !important)

--- a/test/scss/include/test.coffee
+++ b/test/scss/include/test.coffee
@@ -6,3 +6,4 @@ describe 'scss/include >>', ->
   it '3', -> this.shouldBeOk()
   it '4', -> this.shouldBeOk()
   it '5', -> this.shouldBeOk()
+  it '6', -> this.shouldBeOk()


### PR DESCRIPTION
This PR fixes a parse error that occurs when flags are passed as arguments like noted in #168;

``` scss
.no-transitions {
  @include transition(none !important);
}
```

It adds support for `!important`,`!global`, `!default` and `!optional`

Fixes #168 
