### PR TITLE
[SCSS | Sass] - Allow use of @content with keyframes

### DIFF
--- a/src/sass/parse.js
+++ b/src/sass/parse.js
@@ -2420,6 +2420,8 @@ function getKeyframesBlocks() {
   while (pos < keyframesBlocksEnd) {
     if (checkSC(pos)) content = content.concat(getSC());
     else if (checkKeyframesBlock(pos)) content.push(getKeyframesBlock());
+    else if (checkAtrule(pos)) content.push(getAtrule()); // @content
+    else break;
   }
 
   return newNode(type, content, line, column);

--- a/src/scss/parse.js
+++ b/src/scss/parse.js
@@ -2118,6 +2118,8 @@ function getKeyframesBlocks() {
   while (pos < keyframesBlocksEnd) {
     if (checkSC(pos)) content = content.concat(getSC());
     else if (checkKeyframesBlock(pos)) content.push(getKeyframesBlock());
+    else if (checkAtrule(pos)) content.push(getAtrule()); // @content
+    else break;
   }
 
   var end = getLastPosition(content, line, column, 1);

--- a/test/sass/atrule/keyframes.6.json
+++ b/test/sass/atrule/keyframes.6.json
@@ -1,0 +1,148 @@
+{
+  "type": "atrule",
+  "content": [
+    {
+      "type": "atkeyword",
+      "content": [
+        {
+          "type": "ident",
+          "content": "keyframes",
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 2
+          },
+          "end": {
+            "line": 1,
+            "column": 10
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 1,
+        "column": 10
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 11
+      },
+      "end": {
+        "line": 1,
+        "column": 11
+      }
+    },
+    {
+      "type": "ident",
+      "content": "foo",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 12
+      },
+      "end": {
+        "line": 1,
+        "column": 14
+      }
+    },
+    {
+      "type": "space",
+      "content": "\n",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 15
+      },
+      "end": {
+        "line": 1,
+        "column": 15
+      }
+    },
+    {
+      "type": "block",
+      "content": [
+        {
+          "type": "space",
+          "content": "  ",
+          "syntax": "sass",
+          "start": {
+            "line": 2,
+            "column": 1
+          },
+          "end": {
+            "line": 2,
+            "column": 2
+          }
+        },
+        {
+          "type": "atrule",
+          "content": [
+            {
+              "type": "atkeyword",
+              "content": [
+                {
+                  "type": "ident",
+                  "content": "content",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 10
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 2,
+                "column": 10
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 2,
+            "column": 3
+          },
+          "end": {
+            "line": 2,
+            "column": 10
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 2,
+        "column": 1
+      },
+      "end": {
+        "line": 2,
+        "column": 10
+      }
+    }
+  ],
+  "syntax": "sass",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 2,
+    "column": 10
+  }
+}

--- a/test/sass/atrule/keyframes.6.sass
+++ b/test/sass/atrule/keyframes.6.sass
@@ -1,0 +1,2 @@
+@keyframes foo
+  @content

--- a/test/sass/atrule/test.coffee
+++ b/test/sass/atrule/test.coffee
@@ -18,3 +18,4 @@ describe 'sass/atrule >>', ->
   it 'keyframes.3', -> this.shouldBeOk()
   it 'keyframes.4', -> this.shouldBeOk()
   it 'keyframes.5', -> this.shouldBeOk()
+  it 'keyframes.6', -> this.shouldBeOk()

--- a/test/sass/mixin/8.json
+++ b/test/sass/mixin/8.json
@@ -1,0 +1,297 @@
+{
+  "type": "mixin",
+  "content": [
+    {
+      "type": "operator",
+      "content": "=",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 1,
+        "column": 1
+      }
+    },
+    {
+      "type": "ident",
+      "content": "keyframes",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 2
+      },
+      "end": {
+        "line": 1,
+        "column": 10
+      }
+    },
+    {
+      "type": "arguments",
+      "content": [
+        {
+          "type": "variable",
+          "content": [
+            {
+              "type": "ident",
+              "content": "foo",
+              "syntax": "sass",
+              "start": {
+                "line": 1,
+                "column": 13
+              },
+              "end": {
+                "line": 1,
+                "column": 15
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 12
+          },
+          "end": {
+            "line": 1,
+            "column": 15
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 11
+      },
+      "end": {
+        "line": 1,
+        "column": 16
+      }
+    },
+    {
+      "type": "space",
+      "content": "\n",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 17
+      },
+      "end": {
+        "line": 1,
+        "column": 17
+      }
+    },
+    {
+      "type": "block",
+      "content": [
+        {
+          "type": "space",
+          "content": "  ",
+          "syntax": "sass",
+          "start": {
+            "line": 2,
+            "column": 1
+          },
+          "end": {
+            "line": 2,
+            "column": 2
+          }
+        },
+        {
+          "type": "atrule",
+          "content": [
+            {
+              "type": "atkeyword",
+              "content": [
+                {
+                  "type": "ident",
+                  "content": "keyframes",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 12
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 2,
+                "column": 12
+              }
+            },
+            {
+              "type": "space",
+              "content": " ",
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 13
+              },
+              "end": {
+                "line": 2,
+                "column": 13
+              }
+            },
+            {
+              "type": "interpolation",
+              "content": [
+                {
+                  "type": "variable",
+                  "content": [
+                    {
+                      "type": "ident",
+                      "content": "foo",
+                      "syntax": "sass",
+                      "start": {
+                        "line": 2,
+                        "column": 17
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 19
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 16
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 19
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 14
+              },
+              "end": {
+                "line": 2,
+                "column": 20
+              }
+            },
+            {
+              "type": "space",
+              "content": "\n",
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 21
+              },
+              "end": {
+                "line": 2,
+                "column": 21
+              }
+            },
+            {
+              "type": "block",
+              "content": [
+                {
+                  "type": "space",
+                  "content": "    ",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 3,
+                    "column": 1
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 4
+                  }
+                },
+                {
+                  "type": "atrule",
+                  "content": [
+                    {
+                      "type": "atkeyword",
+                      "content": [
+                        {
+                          "type": "ident",
+                          "content": "content",
+                          "syntax": "sass",
+                          "start": {
+                            "line": 3,
+                            "column": 6
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 12
+                          }
+                        }
+                      ],
+                      "syntax": "sass",
+                      "start": {
+                        "line": 3,
+                        "column": 5
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 12
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 3,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 12
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 3,
+                "column": 1
+              },
+              "end": {
+                "line": 3,
+                "column": 12
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 2,
+            "column": 3
+          },
+          "end": {
+            "line": 3,
+            "column": 12
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 2,
+        "column": 1
+      },
+      "end": {
+        "line": 3,
+        "column": 12
+      }
+    }
+  ],
+  "syntax": "sass",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 3,
+    "column": 12
+  }
+}

--- a/test/sass/mixin/8.sass
+++ b/test/sass/mixin/8.sass
@@ -1,0 +1,3 @@
+=keyframes($foo)
+  @keyframes #{$foo}
+    @content

--- a/test/sass/mixin/test.coffee
+++ b/test/sass/mixin/test.coffee
@@ -8,3 +8,4 @@ describe 'sass/mixin >>', ->
   it '5', -> this.shouldBeOk()
   it '6', -> this.shouldBeOk()
   it '7', -> this.shouldBeOk()
+  it '8', -> this.shouldBeOk()

--- a/test/scss/atrule/keyframes.6.json
+++ b/test/scss/atrule/keyframes.6.json
@@ -1,0 +1,174 @@
+{
+  "type": "atrule",
+  "content": [
+    {
+      "type": "atkeyword",
+      "content": [
+        {
+          "type": "ident",
+          "content": "keyframes",
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 2
+          },
+          "end": {
+            "line": 1,
+            "column": 10
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 1,
+        "column": 10
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 11
+      },
+      "end": {
+        "line": 1,
+        "column": 11
+      }
+    },
+    {
+      "type": "ident",
+      "content": "foo",
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 12
+      },
+      "end": {
+        "line": 1,
+        "column": 14
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 15
+      },
+      "end": {
+        "line": 1,
+        "column": 15
+      }
+    },
+    {
+      "type": "block",
+      "content": [
+        {
+          "type": "space",
+          "content": "\n  ",
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 17
+          },
+          "end": {
+            "line": 2,
+            "column": 2
+          }
+        },
+        {
+          "type": "atrule",
+          "content": [
+            {
+              "type": "atkeyword",
+              "content": [
+                {
+                  "type": "ident",
+                  "content": "content",
+                  "syntax": "scss",
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 10
+                  }
+                }
+              ],
+              "syntax": "scss",
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 2,
+                "column": 10
+              }
+            }
+          ],
+          "syntax": "scss",
+          "start": {
+            "line": 2,
+            "column": 3
+          },
+          "end": {
+            "line": 2,
+            "column": 10
+          }
+        },
+        {
+          "type": "declarationDelimiter",
+          "content": ";",
+          "syntax": "scss",
+          "start": {
+            "line": 2,
+            "column": 11
+          },
+          "end": {
+            "line": 2,
+            "column": 11
+          }
+        },
+        {
+          "type": "space",
+          "content": "\n",
+          "syntax": "scss",
+          "start": {
+            "line": 2,
+            "column": 12
+          },
+          "end": {
+            "line": 2,
+            "column": 12
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 16
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    }
+  ],
+  "syntax": "scss",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 3,
+    "column": 1
+  }
+}

--- a/test/scss/atrule/keyframes.6.scss
+++ b/test/scss/atrule/keyframes.6.scss
@@ -1,0 +1,3 @@
+@keyframes foo {
+  @content;
+}

--- a/test/scss/atrule/test.coffee
+++ b/test/scss/atrule/test.coffee
@@ -34,3 +34,4 @@ describe 'scss/atrule >>', ->
   it 'keyframes.3', -> this.shouldBeOk()
   it 'keyframes.4', -> this.shouldBeOk()
   it 'keyframes.5', -> this.shouldBeOk()
+  it 'keyframes.6', -> this.shouldBeOk()

--- a/test/scss/mixin/4.json
+++ b/test/scss/mixin/4.json
@@ -1,0 +1,363 @@
+{
+  "type": "mixin",
+  "content": [
+    {
+      "type": "atkeyword",
+      "content": [
+        {
+          "type": "ident",
+          "content": "mixin",
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 2
+          },
+          "end": {
+            "line": 1,
+            "column": 6
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 1,
+        "column": 6
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 7
+      },
+      "end": {
+        "line": 1,
+        "column": 7
+      }
+    },
+    {
+      "type": "ident",
+      "content": "keyframes",
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 8
+      },
+      "end": {
+        "line": 1,
+        "column": 16
+      }
+    },
+    {
+      "type": "arguments",
+      "content": [
+        {
+          "type": "variable",
+          "content": [
+            {
+              "type": "ident",
+              "content": "foo",
+              "syntax": "scss",
+              "start": {
+                "line": 1,
+                "column": 19
+              },
+              "end": {
+                "line": 1,
+                "column": 21
+              }
+            }
+          ],
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 18
+          },
+          "end": {
+            "line": 1,
+            "column": 21
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 17
+      },
+      "end": {
+        "line": 1,
+        "column": 22
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 23
+      },
+      "end": {
+        "line": 1,
+        "column": 23
+      }
+    },
+    {
+      "type": "block",
+      "content": [
+        {
+          "type": "space",
+          "content": "\n  ",
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 25
+          },
+          "end": {
+            "line": 2,
+            "column": 2
+          }
+        },
+        {
+          "type": "atrule",
+          "content": [
+            {
+              "type": "atkeyword",
+              "content": [
+                {
+                  "type": "ident",
+                  "content": "keyframes",
+                  "syntax": "scss",
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 12
+                  }
+                }
+              ],
+              "syntax": "scss",
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 2,
+                "column": 12
+              }
+            },
+            {
+              "type": "space",
+              "content": " ",
+              "syntax": "scss",
+              "start": {
+                "line": 2,
+                "column": 13
+              },
+              "end": {
+                "line": 2,
+                "column": 13
+              }
+            },
+            {
+              "type": "interpolation",
+              "content": [
+                {
+                  "type": "variable",
+                  "content": [
+                    {
+                      "type": "ident",
+                      "content": "foo",
+                      "syntax": "scss",
+                      "start": {
+                        "line": 2,
+                        "column": 17
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 19
+                      }
+                    }
+                  ],
+                  "syntax": "scss",
+                  "start": {
+                    "line": 2,
+                    "column": 16
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 19
+                  }
+                }
+              ],
+              "syntax": "scss",
+              "start": {
+                "line": 2,
+                "column": 14
+              },
+              "end": {
+                "line": 2,
+                "column": 20
+              }
+            },
+            {
+              "type": "space",
+              "content": " ",
+              "syntax": "scss",
+              "start": {
+                "line": 2,
+                "column": 21
+              },
+              "end": {
+                "line": 2,
+                "column": 21
+              }
+            },
+            {
+              "type": "block",
+              "content": [
+                {
+                  "type": "space",
+                  "content": "\n    ",
+                  "syntax": "scss",
+                  "start": {
+                    "line": 2,
+                    "column": 23
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 4
+                  }
+                },
+                {
+                  "type": "atrule",
+                  "content": [
+                    {
+                      "type": "atkeyword",
+                      "content": [
+                        {
+                          "type": "ident",
+                          "content": "content",
+                          "syntax": "scss",
+                          "start": {
+                            "line": 3,
+                            "column": 6
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 12
+                          }
+                        }
+                      ],
+                      "syntax": "scss",
+                      "start": {
+                        "line": 3,
+                        "column": 5
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 12
+                      }
+                    }
+                  ],
+                  "syntax": "scss",
+                  "start": {
+                    "line": 3,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 12
+                  }
+                },
+                {
+                  "type": "declarationDelimiter",
+                  "content": ";",
+                  "syntax": "scss",
+                  "start": {
+                    "line": 3,
+                    "column": 13
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 13
+                  }
+                },
+                {
+                  "type": "space",
+                  "content": "\n  ",
+                  "syntax": "scss",
+                  "start": {
+                    "line": 3,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 2
+                  }
+                }
+              ],
+              "syntax": "scss",
+              "start": {
+                "line": 2,
+                "column": 22
+              },
+              "end": {
+                "line": 4,
+                "column": 3
+              }
+            }
+          ],
+          "syntax": "scss",
+          "start": {
+            "line": 2,
+            "column": 3
+          },
+          "end": {
+            "line": 4,
+            "column": 3
+          }
+        },
+        {
+          "type": "space",
+          "content": "\n",
+          "syntax": "scss",
+          "start": {
+            "line": 4,
+            "column": 4
+          },
+          "end": {
+            "line": 4,
+            "column": 4
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 24
+      },
+      "end": {
+        "line": 5,
+        "column": 1
+      }
+    }
+  ],
+  "syntax": "scss",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 5,
+    "column": 1
+  }
+}

--- a/test/scss/mixin/4.scss
+++ b/test/scss/mixin/4.scss
@@ -1,0 +1,5 @@
+@mixin keyframes($foo) {
+  @keyframes #{$foo} {
+    @content;
+  }
+}

--- a/test/scss/mixin/test.coffee
+++ b/test/scss/mixin/test.coffee
@@ -4,3 +4,4 @@ describe 'scss/mixin >>', ->
   it '1', -> this.shouldBeOk()
   it '2', -> this.shouldBeOk()
   it '3', -> this.shouldBeOk()
+  it '4', -> this.shouldBeOk()


### PR DESCRIPTION
This PR fixes an infinite loop when one would wrap `@keyframes` within a mixing and use `@content` as noted in #159. When getting keyframe blocks it now checks for if there is an atrule as well. 

SCSS;

``` scss
@mixin keyframes($name) {
  @keyframes #{$name} {
    @content;
  }
}
```

Sass;

``` sass
=keyframes($name)
  @keyframes #{$name}
    @content
```

Fixes #159 
