### PR TITLE
[Sass] Improve comment handling

### DIFF
--- a/src/sass/parse.js
+++ b/src/sass/parse.js
@@ -1356,11 +1356,19 @@ function checkCommentML(i) {
 function getCommentML() {
   let startPos = pos;
   let x = tokens[pos].value.substring(2);
+  let l = x.length;
+  let closed = false;
   var token = tokens[startPos];
   var line = token.ln;
   var column = token.col;
 
+  if (x.charAt(l - 2) === '*' && x.charAt(l - 1) === '/') {
+    x = x.substring(0, l - 2);
+    closed = true;
+  }
+
   var end = getLastPosition(x, line, column + 2);
+  if (closed) end[1] += 2;
   pos++;
 
   return newNode(NodeType.CommentMLType, x, token.ln, token.col, end);

--- a/src/sass/stringify.js
+++ b/src/sass/stringify.js
@@ -53,7 +53,19 @@ module.exports = function stringify(tree) {
       return '#{' + _composite(t.content) + '}';
     },
     'multilineComment': function(t) {
-      return '/*' + t.content;
+      var lines = t.content.split('\n');
+      var close = '';
+
+      if (lines.length > 1) {
+        var lastLine = lines[lines.length - 1];
+        if (lastLine.length < t.end.column) {
+          close = '*/';
+        }
+      } else if (t.content.length + 4 === t.end.column - t.start.column + 1) {
+        close = '*/';
+      }
+
+      return '/*' + t.content + close;
     },
     'nthSelector': function(t) {
       return ':' + _t(t.content[0]) +

--- a/src/sass/tokenizer.js
+++ b/src/sass/tokenizer.js
@@ -194,7 +194,8 @@ module.exports = function(css, tabSize) {
     }
 
     for (pos += 2; pos < css.length; pos++) {
-      if (css.charAt(pos) === '\n') {
+      let ch = css.charAt(pos);
+      if (ch === '\n') {
         let _pos;
         // Get new line's indent level:
         var _il = 0;
@@ -210,10 +211,13 @@ module.exports = function(css, tabSize) {
           pos--;
           break;
         }
+      } else if (ch === '*' && css.charAt(pos + 1) === '/') {
+        pos++;
+        break;
       }
     }
 
-    // Add full comment (including `/*`) to the list of tokens:
+    // Add full comment (excluding `/*`) to the list of tokens:
     var comment = css.substring(start, pos + 1);
     pushToken(TokenType.CommentML, comment, col_);
 
@@ -260,7 +264,8 @@ module.exports = function(css, tabSize) {
       }
     } else {
       for (pos += 2; pos < css.length; pos++) {
-        if (css.charAt(pos) === '\n') {
+        var ch = css.charAt(pos);
+        if (ch === '\n') {
           // Get new line's indent level:
           var _il = 0;
           for (_pos = pos + 1; _pos < css.length; _pos++) {

--- a/test/sass/commentML/1.json
+++ b/test/sass/commentML/1.json
@@ -1,6 +1,6 @@
 {
   "type": "multilineComment",
-  "content": "test*/",
+  "content": "test",
   "syntax": "sass",
   "start": {
     "line": 1,

--- a/test/sass/ruleset/issue213.json
+++ b/test/sass/ruleset/issue213.json
@@ -1,0 +1,282 @@
+{
+  "type": "ruleset",
+  "content": [
+    {
+      "type": "selector",
+      "content": [
+        {
+          "type": "typeSelector",
+          "content": [
+            {
+              "type": "ident",
+              "content": "a",
+              "syntax": "sass",
+              "start": {
+                "line": 1,
+                "column": 1
+              },
+              "end": {
+                "line": 1,
+                "column": 1
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 1,
+            "column": 1
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 1,
+        "column": 1
+      }
+    },
+    {
+      "type": "delimiter",
+      "content": ",",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 2
+      },
+      "end": {
+        "line": 1,
+        "column": 2
+      }
+    },
+    {
+      "type": "space",
+      "content": "\n",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 3
+      },
+      "end": {
+        "line": 1,
+        "column": 3
+      }
+    },
+    {
+      "type": "singlelineComment",
+      "content": " li,",
+      "syntax": "sass",
+      "start": {
+        "line": 2,
+        "column": 1
+      },
+      "end": {
+        "line": 2,
+        "column": 6
+      }
+    },
+    {
+      "type": "space",
+      "content": "\n",
+      "syntax": "sass",
+      "start": {
+        "line": 2,
+        "column": 7
+      },
+      "end": {
+        "line": 2,
+        "column": 7
+      }
+    },
+    {
+      "type": "selector",
+      "content": [
+        {
+          "type": "typeSelector",
+          "content": [
+            {
+              "type": "ident",
+              "content": "p",
+              "syntax": "sass",
+              "start": {
+                "line": 3,
+                "column": 1
+              },
+              "end": {
+                "line": 3,
+                "column": 1
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 3,
+            "column": 1
+          },
+          "end": {
+            "line": 3,
+            "column": 1
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 3,
+        "column": 1
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    },
+    {
+      "type": "space",
+      "content": "\n",
+      "syntax": "sass",
+      "start": {
+        "line": 3,
+        "column": 2
+      },
+      "end": {
+        "line": 3,
+        "column": 2
+      }
+    },
+    {
+      "type": "block",
+      "content": [
+        {
+          "type": "space",
+          "content": "  ",
+          "syntax": "sass",
+          "start": {
+            "line": 4,
+            "column": 1
+          },
+          "end": {
+            "line": 4,
+            "column": 2
+          }
+        },
+        {
+          "type": "declaration",
+          "content": [
+            {
+              "type": "property",
+              "content": [
+                {
+                  "type": "ident",
+                  "content": "color",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 4,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 7
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 4,
+                "column": 3
+              },
+              "end": {
+                "line": 4,
+                "column": 7
+              }
+            },
+            {
+              "type": "propertyDelimiter",
+              "content": ":",
+              "syntax": "sass",
+              "start": {
+                "line": 4,
+                "column": 8
+              },
+              "end": {
+                "line": 4,
+                "column": 8
+              }
+            },
+            {
+              "type": "space",
+              "content": " ",
+              "syntax": "sass",
+              "start": {
+                "line": 4,
+                "column": 9
+              },
+              "end": {
+                "line": 4,
+                "column": 9
+              }
+            },
+            {
+              "type": "value",
+              "content": [
+                {
+                  "type": "ident",
+                  "content": "red",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 4,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 12
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 4,
+                "column": 10
+              },
+              "end": {
+                "line": 4,
+                "column": 12
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 4,
+            "column": 3
+          },
+          "end": {
+            "line": 4,
+            "column": 12
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 4,
+        "column": 1
+      },
+      "end": {
+        "line": 4,
+        "column": 12
+      }
+    }
+  ],
+  "syntax": "sass",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 4,
+    "column": 12
+  }
+}

--- a/test/sass/ruleset/issue213.sass
+++ b/test/sass/ruleset/issue213.sass
@@ -1,0 +1,4 @@
+a,
+// li,
+p
+  color: red

--- a/test/sass/ruleset/test.coffee
+++ b/test/sass/ruleset/test.coffee
@@ -15,6 +15,7 @@ describe 'sass/ruleset >>', ->
   it 'color.ident.1', -> this.shouldBeOk()
   it 'issue-119-1', -> this.shouldBeOk()
   it 'issue-119-2', -> this.shouldBeOk()
+  it 'issue213', -> this.shouldBeOk()
 
   it 'nested.mixin.0', -> this.shouldBeOk()
   it 'nested.mixin.1', -> this.shouldBeOk()

--- a/test/sass/stylesheet/c.0.json
+++ b/test/sass/stylesheet/c.0.json
@@ -3,7 +3,7 @@
   "content": [
     {
       "type": "multilineComment",
-      "content": " test */",
+      "content": " test ",
       "syntax": "sass",
       "start": {
         "line": 1,
@@ -244,7 +244,7 @@
     },
     {
       "type": "multilineComment",
-      "content": " test */",
+      "content": " test ",
       "syntax": "sass",
       "start": {
         "line": 5,

--- a/test/sass/stylesheet/issue211.json
+++ b/test/sass/stylesheet/issue211.json
@@ -1,0 +1,296 @@
+{
+  "type": "stylesheet",
+  "content": [
+    {
+      "type": "ruleset",
+      "content": [
+        {
+          "type": "selector",
+          "content": [
+            {
+              "type": "typeSelector",
+              "content": [
+                {
+                  "type": "ident",
+                  "content": "div",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 1,
+                    "column": 1
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 3
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 1,
+                "column": 1
+              },
+              "end": {
+                "line": 1,
+                "column": 3
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 1,
+            "column": 3
+          }
+        },
+        {
+          "type": "delimiter",
+          "content": ",",
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 4
+          },
+          "end": {
+            "line": 1,
+            "column": 4
+          }
+        },
+        {
+          "type": "space",
+          "content": " ",
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 5
+          },
+          "end": {
+            "line": 1,
+            "column": 5
+          }
+        },
+        {
+          "type": "multilineComment",
+          "content": " banana ",
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 6
+          },
+          "end": {
+            "line": 1,
+            "column": 17
+          }
+        },
+        {
+          "type": "space",
+          "content": " ",
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 18
+          },
+          "end": {
+            "line": 1,
+            "column": 18
+          }
+        },
+        {
+          "type": "selector",
+          "content": [
+            {
+              "type": "typeSelector",
+              "content": [
+                {
+                  "type": "ident",
+                  "content": "span",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 1,
+                    "column": 19
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 22
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 1,
+                "column": 19
+              },
+              "end": {
+                "line": 1,
+                "column": 22
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 19
+          },
+          "end": {
+            "line": 1,
+            "column": 22
+          }
+        },
+        {
+          "type": "space",
+          "content": "\n",
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 23
+          },
+          "end": {
+            "line": 1,
+            "column": 23
+          }
+        },
+        {
+          "type": "block",
+          "content": [
+            {
+              "type": "space",
+              "content": "  ",
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 1
+              },
+              "end": {
+                "line": 2,
+                "column": 2
+              }
+            },
+            {
+              "type": "declaration",
+              "content": [
+                {
+                  "type": "property",
+                  "content": [
+                    {
+                      "type": "ident",
+                      "content": "display",
+                      "syntax": "sass",
+                      "start": {
+                        "line": 2,
+                        "column": 3
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 9
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 9
+                  }
+                },
+                {
+                  "type": "propertyDelimiter",
+                  "content": ":",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 10
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 10
+                  }
+                },
+                {
+                  "type": "space",
+                  "content": " ",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 11
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 11
+                  }
+                },
+                {
+                  "type": "value",
+                  "content": [
+                    {
+                      "type": "ident",
+                      "content": "none",
+                      "syntax": "sass",
+                      "start": {
+                        "line": 2,
+                        "column": 12
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 15
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 12
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 15
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 2,
+                "column": 15
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 2,
+            "column": 1
+          },
+          "end": {
+            "line": 2,
+            "column": 15
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 2,
+        "column": 15
+      }
+    }
+  ],
+  "syntax": "sass",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 2,
+    "column": 15
+  }
+}

--- a/test/sass/stylesheet/issue211.sass
+++ b/test/sass/stylesheet/issue211.sass
@@ -1,0 +1,2 @@
+div, /* banana */ span
+  display: none

--- a/test/sass/stylesheet/test.coffee
+++ b/test/sass/stylesheet/test.coffee
@@ -18,6 +18,7 @@ describe 'sass/stylesheet >>', ->
   it 'issue104', -> this.shouldBeOk()
   it 'issue-147-1', -> this.shouldBeOk()
   it 'issue-147-2', -> this.shouldBeOk()
+  it 'issue211', -> this.shouldBeOk()
 
   it 's.0', -> this.shouldBeOk()
   it 's.1', -> this.shouldBeOk()


### PR DESCRIPTION
Fixes for #211 and #213

Allow multiline and single-line comments to be used in selector goups:

``` sass
a, /* b, */ c
  d: e
```

``` sass
a,
// b,
c
  d: e
```

---

This is a potentially breaking change because the Sass parser no longer considers the closing `*/` in a multiline comment to be a part of the node's contents (consistent with the behavior of the other parsers)
