### PR TITLE
Add context to parsing error

### DIFF
--- a/src/parsing-error.js
+++ b/src/parsing-error.js
@@ -72,6 +72,7 @@ ParsingError.prototype = {
       var message = 'Please check validity of the block';
       if (typeof this.line === 'number')
           message += ' starting from line #' + this.line;
+      message +=  "\n" + this.context;
       return message;
     }
   },


### PR DESCRIPTION
If a parsing error occurs, the error message does only tell you in which line.
If you have more than 1 file that won't help you at all because you have to
check every file. Adding the context to the message does at least tell you
what the error exactly is.
