### PR TITLE
[Sass|SCSS] Fix interps in compound selectors that start with a typeSelector

### DIFF
--- a/src/sass/parse.js
+++ b/src/sass/parse.js
@@ -5694,7 +5694,8 @@ function checkCompoundSelector1(i) {
         checkClass(i) ||
         checkAttributeSelector(i) ||
         checkPseudo(i) ||
-        checkPlaceholder(i);
+        checkPlaceholder(i) ||
+        checkInterpolation(i);
 
     if (l) i += l;
     else break;
@@ -5724,6 +5725,7 @@ function getCompoundSelector1() {
     else if (checkAttributeSelector(pos)) sequence.push(getAttributeSelector());
     else if (checkPseudo(pos)) sequence.push(getPseudo());
     else if (checkPlaceholder(pos)) sequence.push(getPlaceholder());
+    else if (checkInterpolation(pos)) sequence.push(getInterpolation());
     else break;
   }
 

--- a/src/scss/parse.js
+++ b/src/scss/parse.js
@@ -5036,7 +5036,8 @@ function checkCompoundSelector1(i) {
         checkClass(i) ||
         checkAttributeSelector(i) ||
         checkPseudo(i) ||
-        checkPlaceholder(i);
+        checkPlaceholder(i) ||
+        checkInterpolation(i);
 
     if (l) i += l;
     else break;
@@ -5066,6 +5067,7 @@ function getCompoundSelector1() {
     else if (checkAttributeSelector(pos)) sequence.push(getAttributeSelector());
     else if (checkPseudo(pos)) sequence.push(getPseudo());
     else if (checkPlaceholder(pos)) sequence.push(getPlaceholder());
+    else if (checkInterpolation(pos)) sequence.push(getInterpolation());
     else break;
   }
 

--- a/test/sass/selector/interp.8.json
+++ b/test/sass/selector/interp.8.json
@@ -1,0 +1,123 @@
+{
+  "type": "selector",
+  "content": [
+    {
+      "type": "typeSelector",
+      "content": [
+        {
+          "type": "ident",
+          "content": "foo",
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 1,
+            "column": 3
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 1,
+        "column": 3
+      }
+    },
+    {
+      "type": "attributeSelector",
+      "content": [
+        {
+          "type": "attributeName",
+          "content": [
+            {
+              "type": "ident",
+              "content": "attr",
+              "syntax": "sass",
+              "start": {
+                "line": 1,
+                "column": 5
+              },
+              "end": {
+                "line": 1,
+                "column": 8
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 5
+          },
+          "end": {
+            "line": 1,
+            "column": 8
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 4
+      },
+      "end": {
+        "line": 1,
+        "column": 9
+      }
+    },
+    {
+      "type": "interpolation",
+      "content": [
+        {
+          "type": "variable",
+          "content": [
+            {
+              "type": "ident",
+              "content": "bar",
+              "syntax": "sass",
+              "start": {
+                "line": 1,
+                "column": 13
+              },
+              "end": {
+                "line": 1,
+                "column": 15
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 12
+          },
+          "end": {
+            "line": 1,
+            "column": 15
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 10
+      },
+      "end": {
+        "line": 1,
+        "column": 16
+      }
+    }
+  ],
+  "syntax": "sass",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 1,
+    "column": 16
+  }
+}

--- a/test/sass/selector/interp.8.sass
+++ b/test/sass/selector/interp.8.sass
@@ -1,0 +1,1 @@
+foo[attr]#{$bar}

--- a/test/sass/selector/test.coffee
+++ b/test/sass/selector/test.coffee
@@ -34,6 +34,7 @@ describe 'sass/selector >>', ->
   it 'interp.5', -> this.shouldBeOk()
   it 'interp.6', -> this.shouldBeOk()
   it 'interp.7', -> this.shouldBeOk()
+  it 'interp.8', -> this.shouldBeOk()
 
   it 'issue-102', -> this.shouldBeOk()
   it 'issue-102-2', -> this.shouldBeOk()

--- a/test/scss/selector/interp.8.json
+++ b/test/scss/selector/interp.8.json
@@ -1,0 +1,123 @@
+{
+  "type": "selector",
+  "content": [
+    {
+      "type": "typeSelector",
+      "content": [
+        {
+          "type": "ident",
+          "content": "foo",
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 1,
+            "column": 3
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 1,
+        "column": 3
+      }
+    },
+    {
+      "type": "attributeSelector",
+      "content": [
+        {
+          "type": "attributeName",
+          "content": [
+            {
+              "type": "ident",
+              "content": "attr",
+              "syntax": "scss",
+              "start": {
+                "line": 1,
+                "column": 5
+              },
+              "end": {
+                "line": 1,
+                "column": 8
+              }
+            }
+          ],
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 5
+          },
+          "end": {
+            "line": 1,
+            "column": 8
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 4
+      },
+      "end": {
+        "line": 1,
+        "column": 9
+      }
+    },
+    {
+      "type": "interpolation",
+      "content": [
+        {
+          "type": "variable",
+          "content": [
+            {
+              "type": "ident",
+              "content": "bar",
+              "syntax": "scss",
+              "start": {
+                "line": 1,
+                "column": 13
+              },
+              "end": {
+                "line": 1,
+                "column": 15
+              }
+            }
+          ],
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 12
+          },
+          "end": {
+            "line": 1,
+            "column": 15
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 10
+      },
+      "end": {
+        "line": 1,
+        "column": 16
+      }
+    }
+  ],
+  "syntax": "scss",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 1,
+    "column": 16
+  }
+}

--- a/test/scss/selector/interp.8.scss
+++ b/test/scss/selector/interp.8.scss
@@ -1,0 +1,1 @@
+foo[attr]#{$bar}

--- a/test/scss/selector/test.coffee
+++ b/test/scss/selector/test.coffee
@@ -40,6 +40,7 @@ describe 'scss/selector >>', ->
   it 'interp.5', -> this.shouldBeOk()
   it 'interp.6', -> this.shouldBeOk()
   it 'interp.7', -> this.shouldBeOk()
+  it 'interp.8', -> this.shouldBeOk()
 
   it 'issue-100', -> this.shouldBeOk()
   it 'issue-102', -> this.shouldBeOk()


### PR DESCRIPTION
This PR closes https://github.com/tonyganch/gonzales-pe/issues/227 by adding support for interps in compound selectors that start with a typeSelector.

