### PR TITLE
[Sass|SCSS] Add support for pseudo class keyframes

### DIFF
--- a/src/sass/parse.js
+++ b/src/sass/parse.js
@@ -2875,13 +2875,15 @@ function checkKeyframesBlocks(i) {
   if (l = checkSC(i)) i += l;
 
   if (l = checkKeyframesBlock(i)) i += l;
-  else return 0;
 
   while (i < blockEnd) {
     if (l = checkSC(i)) i += l;
     else if (l = checkKeyframesBlock(i)) i += l;
+    else if (l = checkAtrule(i)) i += l;
     else break;
   }
+
+  if (i !== blockEnd + 1) return 0;
 
   return blockEnd + 1 - start;
 }
@@ -2928,7 +2930,7 @@ function checkKeyframesRule(i) {
   if (l = checkSC(i)) i += l;
   else return 0;
 
-  if (l = checkIdentOrInterpolation(i)) i += l;
+  if (l = checkIdentOrInterpolation(i) || checkPseudoc(i)) i += l;
   else return 0;
 
   if (l = checkSC(i)) i += l;
@@ -2947,10 +2949,18 @@ function getKeyframesRule() {
   const token = tokens[pos];
   const line = token.ln;
   const column = token.col;
-  const content = [].concat(
+  let content = [].concat(
     getAtkeyword(),
-    getSC(),
-    getIdentOrInterpolation(),
+    getSC()
+  );
+
+  if (checkIdentOrInterpolation(pos))
+    content = content.concat(getIdentOrInterpolation());
+  else if (checkPseudoc(pos)) {
+    content = content.concat(getPseudoc());
+  }
+
+  content = content.concat(
     getSC(),
     getKeyframesBlocks()
   );
@@ -2960,8 +2970,8 @@ function getKeyframesRule() {
 
 /**
  * Check a single keyframe selector - `5%`, `from` etc
- * @param {number} i
- * @return {number}
+ * @param {Number} i
+ * @return {Number}
  */
 function checkKeyframesSelector(i) {
   const start = i;

--- a/test/sass/atrule/keyframes.7.json
+++ b/test/sass/atrule/keyframes.7.json
@@ -1,0 +1,379 @@
+{
+  "type": "atrule",
+  "content": [
+    {
+      "type": "atkeyword",
+      "content": [
+        {
+          "type": "ident",
+          "content": "keyframes",
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 2
+          },
+          "end": {
+            "line": 1,
+            "column": 10
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 1,
+        "column": 10
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 11
+      },
+      "end": {
+        "line": 1,
+        "column": 11
+      }
+    },
+    {
+      "type": "pseudoClass",
+      "content": [
+        {
+          "type": "ident",
+          "content": "global",
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 13
+          },
+          "end": {
+            "line": 1,
+            "column": 18
+          }
+        },
+        {
+          "type": "arguments",
+          "content": [
+            {
+              "type": "selector",
+              "content": [
+                {
+                  "type": "typeSelector",
+                  "content": [
+                    {
+                      "type": "ident",
+                      "content": "foo",
+                      "syntax": "sass",
+                      "start": {
+                        "line": 1,
+                        "column": 20
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 22
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 1,
+                    "column": 20
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 22
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 1,
+                "column": 20
+              },
+              "end": {
+                "line": 1,
+                "column": 22
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 19
+          },
+          "end": {
+            "line": 1,
+            "column": 23
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 12
+      },
+      "end": {
+        "line": 1,
+        "column": 23
+      }
+    },
+    {
+      "type": "space",
+      "content": "\n",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 24
+      },
+      "end": {
+        "line": 1,
+        "column": 24
+      }
+    },
+    {
+      "type": "block",
+      "content": [
+        {
+          "type": "space",
+          "content": "  ",
+          "syntax": "sass",
+          "start": {
+            "line": 2,
+            "column": 1
+          },
+          "end": {
+            "line": 2,
+            "column": 2
+          }
+        },
+        {
+          "type": "ruleset",
+          "content": [
+            {
+              "type": "selector",
+              "content": [
+                {
+                  "type": "keyframesSelector",
+                  "content": [
+                    {
+                      "type": "percentage",
+                      "content": [
+                        {
+                          "type": "number",
+                          "content": "0",
+                          "syntax": "sass",
+                          "start": {
+                            "line": 2,
+                            "column": 3
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 3
+                          }
+                        }
+                      ],
+                      "syntax": "sass",
+                      "start": {
+                        "line": 2,
+                        "column": 3
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 4
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 4
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 2,
+                "column": 4
+              }
+            },
+            {
+              "type": "space",
+              "content": "\n",
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 5
+              },
+              "end": {
+                "line": 2,
+                "column": 5
+              }
+            },
+            {
+              "type": "block",
+              "content": [
+                {
+                  "type": "space",
+                  "content": "    ",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 3,
+                    "column": 1
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 4
+                  }
+                },
+                {
+                  "type": "declaration",
+                  "content": [
+                    {
+                      "type": "property",
+                      "content": [
+                        {
+                          "type": "ident",
+                          "content": "content",
+                          "syntax": "sass",
+                          "start": {
+                            "line": 3,
+                            "column": 5
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 11
+                          }
+                        }
+                      ],
+                      "syntax": "sass",
+                      "start": {
+                        "line": 3,
+                        "column": 5
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 11
+                      }
+                    },
+                    {
+                      "type": "propertyDelimiter",
+                      "content": ":",
+                      "syntax": "sass",
+                      "start": {
+                        "line": 3,
+                        "column": 12
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 12
+                      }
+                    },
+                    {
+                      "type": "space",
+                      "content": " ",
+                      "syntax": "sass",
+                      "start": {
+                        "line": 3,
+                        "column": 13
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 13
+                      }
+                    },
+                    {
+                      "type": "value",
+                      "content": [
+                        {
+                          "type": "string",
+                          "content": "'foo'",
+                          "syntax": "sass",
+                          "start": {
+                            "line": 3,
+                            "column": 14
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 18
+                          }
+                        }
+                      ],
+                      "syntax": "sass",
+                      "start": {
+                        "line": 3,
+                        "column": 14
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 18
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 3,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 18
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 3,
+                "column": 1
+              },
+              "end": {
+                "line": 3,
+                "column": 18
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 2,
+            "column": 3
+          },
+          "end": {
+            "line": 3,
+            "column": 18
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 2,
+        "column": 1
+      },
+      "end": {
+        "line": 3,
+        "column": 18
+      }
+    }
+  ],
+  "syntax": "sass",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 3,
+    "column": 18
+  }
+}

--- a/test/sass/atrule/keyframes.7.sass
+++ b/test/sass/atrule/keyframes.7.sass
@@ -1,0 +1,3 @@
+@keyframes :global(foo)
+  0%
+    content: 'foo'

--- a/test/sass/atrule/keyframes.8.json
+++ b/test/sass/atrule/keyframes.8.json
@@ -1,0 +1,217 @@
+{
+  "type": "atrule",
+  "content": [
+    {
+      "type": "atkeyword",
+      "content": [
+        {
+          "type": "ident",
+          "content": "keyframes",
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 2
+          },
+          "end": {
+            "line": 1,
+            "column": 10
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 1,
+        "column": 10
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 11
+      },
+      "end": {
+        "line": 1,
+        "column": 11
+      }
+    },
+    {
+      "type": "pseudoClass",
+      "content": [
+        {
+          "type": "ident",
+          "content": "global",
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 13
+          },
+          "end": {
+            "line": 1,
+            "column": 18
+          }
+        },
+        {
+          "type": "arguments",
+          "content": [
+            {
+              "type": "selector",
+              "content": [
+                {
+                  "type": "typeSelector",
+                  "content": [
+                    {
+                      "type": "ident",
+                      "content": "foo",
+                      "syntax": "sass",
+                      "start": {
+                        "line": 1,
+                        "column": 20
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 22
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 1,
+                    "column": 20
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 22
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 1,
+                "column": 20
+              },
+              "end": {
+                "line": 1,
+                "column": 22
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 19
+          },
+          "end": {
+            "line": 1,
+            "column": 23
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 12
+      },
+      "end": {
+        "line": 1,
+        "column": 23
+      }
+    },
+    {
+      "type": "space",
+      "content": "\n",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 24
+      },
+      "end": {
+        "line": 1,
+        "column": 24
+      }
+    },
+    {
+      "type": "block",
+      "content": [
+        {
+          "type": "space",
+          "content": "  ",
+          "syntax": "sass",
+          "start": {
+            "line": 2,
+            "column": 1
+          },
+          "end": {
+            "line": 2,
+            "column": 2
+          }
+        },
+        {
+          "type": "atrule",
+          "content": [
+            {
+              "type": "atkeyword",
+              "content": [
+                {
+                  "type": "ident",
+                  "content": "content",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 10
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 2,
+                "column": 10
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 2,
+            "column": 3
+          },
+          "end": {
+            "line": 2,
+            "column": 10
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 2,
+        "column": 1
+      },
+      "end": {
+        "line": 2,
+        "column": 10
+      }
+    }
+  ],
+  "syntax": "sass",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 2,
+    "column": 10
+  }
+}

--- a/test/sass/atrule/keyframes.8.sass
+++ b/test/sass/atrule/keyframes.8.sass
@@ -1,0 +1,2 @@
+@keyframes :global(foo)
+  @content

--- a/test/sass/atrule/test.coffee
+++ b/test/sass/atrule/test.coffee
@@ -24,6 +24,8 @@ describe 'sass/atrule >>', ->
   it 'keyframes.4', -> this.shouldBeOk()
   it 'keyframes.5', -> this.shouldBeOk()
   it 'keyframes.6', -> this.shouldBeOk()
+  it 'keyframes.7', -> this.shouldBeOk()
+  it 'keyframes.8', -> this.shouldBeOk()
 
   it 'keyframes.interp.0', -> this.shouldBeOk()
   it 'keyframes.interp.1', -> this.shouldBeOk()

--- a/test/scss/atrule/keyframes.7.json
+++ b/test/scss/atrule/keyframes.7.json
@@ -1,0 +1,162 @@
+{
+  "type": "atrule",
+  "content": [
+    {
+      "type": "atkeyword",
+      "content": [
+        {
+          "type": "ident",
+          "content": "keyframes",
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 2
+          },
+          "end": {
+            "line": 1,
+            "column": 10
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 1,
+        "column": 10
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 11
+      },
+      "end": {
+        "line": 1,
+        "column": 11
+      }
+    },
+    {
+      "type": "pseudoClass",
+      "content": [
+        {
+          "type": "ident",
+          "content": "global",
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 13
+          },
+          "end": {
+            "line": 1,
+            "column": 18
+          }
+        },
+        {
+          "type": "arguments",
+          "content": [
+            {
+              "type": "selector",
+              "content": [
+                {
+                  "type": "typeSelector",
+                  "content": [
+                    {
+                      "type": "ident",
+                      "content": "foo",
+                      "syntax": "scss",
+                      "start": {
+                        "line": 1,
+                        "column": 20
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 22
+                      }
+                    }
+                  ],
+                  "syntax": "scss",
+                  "start": {
+                    "line": 1,
+                    "column": 20
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 22
+                  }
+                }
+              ],
+              "syntax": "scss",
+              "start": {
+                "line": 1,
+                "column": 20
+              },
+              "end": {
+                "line": 1,
+                "column": 22
+              }
+            }
+          ],
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 19
+          },
+          "end": {
+            "line": 1,
+            "column": 23
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 12
+      },
+      "end": {
+        "line": 1,
+        "column": 23
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 24
+      },
+      "end": {
+        "line": 1,
+        "column": 24
+      }
+    },
+    {
+      "type": "block",
+      "content": [],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 25
+      },
+      "end": {
+        "line": 1,
+        "column": 26
+      }
+    }
+  ],
+  "syntax": "scss",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 1,
+    "column": 26
+  }
+}

--- a/test/scss/atrule/keyframes.7.scss
+++ b/test/scss/atrule/keyframes.7.scss
@@ -1,0 +1,1 @@
+@keyframes :global(foo) {}

--- a/test/scss/atrule/keyframes.8.json
+++ b/test/scss/atrule/keyframes.8.json
@@ -1,0 +1,258 @@
+{
+  "type": "atrule",
+  "content": [
+    {
+      "type": "atkeyword",
+      "content": [
+        {
+          "type": "ident",
+          "content": "keyframes",
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 2
+          },
+          "end": {
+            "line": 1,
+            "column": 10
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 1,
+        "column": 10
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 11
+      },
+      "end": {
+        "line": 1,
+        "column": 11
+      }
+    },
+    {
+      "type": "pseudoClass",
+      "content": [
+        {
+          "type": "ident",
+          "content": "global",
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 13
+          },
+          "end": {
+            "line": 1,
+            "column": 18
+          }
+        },
+        {
+          "type": "arguments",
+          "content": [
+            {
+              "type": "selector",
+              "content": [
+                {
+                  "type": "typeSelector",
+                  "content": [
+                    {
+                      "type": "ident",
+                      "content": "foo",
+                      "syntax": "scss",
+                      "start": {
+                        "line": 1,
+                        "column": 20
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 22
+                      }
+                    }
+                  ],
+                  "syntax": "scss",
+                  "start": {
+                    "line": 1,
+                    "column": 20
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 22
+                  }
+                }
+              ],
+              "syntax": "scss",
+              "start": {
+                "line": 1,
+                "column": 20
+              },
+              "end": {
+                "line": 1,
+                "column": 22
+              }
+            }
+          ],
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 19
+          },
+          "end": {
+            "line": 1,
+            "column": 23
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 12
+      },
+      "end": {
+        "line": 1,
+        "column": 23
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 24
+      },
+      "end": {
+        "line": 1,
+        "column": 24
+      }
+    },
+    {
+      "type": "block",
+      "content": [
+        {
+          "type": "ruleset",
+          "content": [
+            {
+              "type": "selector",
+              "content": [
+                {
+                  "type": "keyframesSelector",
+                  "content": [
+                    {
+                      "type": "percentage",
+                      "content": [
+                        {
+                          "type": "number",
+                          "content": "0",
+                          "syntax": "scss",
+                          "start": {
+                            "line": 1,
+                            "column": 26
+                          },
+                          "end": {
+                            "line": 1,
+                            "column": 26
+                          }
+                        }
+                      ],
+                      "syntax": "scss",
+                      "start": {
+                        "line": 1,
+                        "column": 26
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 27
+                      }
+                    }
+                  ],
+                  "syntax": "scss",
+                  "start": {
+                    "line": 1,
+                    "column": 26
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 27
+                  }
+                }
+              ],
+              "syntax": "scss",
+              "start": {
+                "line": 1,
+                "column": 26
+              },
+              "end": {
+                "line": 1,
+                "column": 27
+              }
+            },
+            {
+              "type": "space",
+              "content": " ",
+              "syntax": "scss",
+              "start": {
+                "line": 1,
+                "column": 28
+              },
+              "end": {
+                "line": 1,
+                "column": 28
+              }
+            },
+            {
+              "type": "block",
+              "content": [],
+              "syntax": "scss",
+              "start": {
+                "line": 1,
+                "column": 29
+              },
+              "end": {
+                "line": 1,
+                "column": 30
+              }
+            }
+          ],
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 26
+          },
+          "end": {
+            "line": 1,
+            "column": 30
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 25
+      },
+      "end": {
+        "line": 1,
+        "column": 31
+      }
+    }
+  ],
+  "syntax": "scss",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 1,
+    "column": 31
+  }
+}

--- a/test/scss/atrule/keyframes.8.scss
+++ b/test/scss/atrule/keyframes.8.scss
@@ -1,0 +1,1 @@
+@keyframes :global(foo) {0% {}}

--- a/test/scss/atrule/keyframes.9.json
+++ b/test/scss/atrule/keyframes.9.json
@@ -1,0 +1,243 @@
+{
+  "type": "atrule",
+  "content": [
+    {
+      "type": "atkeyword",
+      "content": [
+        {
+          "type": "ident",
+          "content": "keyframes",
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 2
+          },
+          "end": {
+            "line": 1,
+            "column": 10
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 1,
+        "column": 10
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 11
+      },
+      "end": {
+        "line": 1,
+        "column": 11
+      }
+    },
+    {
+      "type": "pseudoClass",
+      "content": [
+        {
+          "type": "ident",
+          "content": "global",
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 13
+          },
+          "end": {
+            "line": 1,
+            "column": 18
+          }
+        },
+        {
+          "type": "arguments",
+          "content": [
+            {
+              "type": "selector",
+              "content": [
+                {
+                  "type": "typeSelector",
+                  "content": [
+                    {
+                      "type": "ident",
+                      "content": "foo",
+                      "syntax": "scss",
+                      "start": {
+                        "line": 1,
+                        "column": 20
+                      },
+                      "end": {
+                        "line": 1,
+                        "column": 22
+                      }
+                    }
+                  ],
+                  "syntax": "scss",
+                  "start": {
+                    "line": 1,
+                    "column": 20
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 22
+                  }
+                }
+              ],
+              "syntax": "scss",
+              "start": {
+                "line": 1,
+                "column": 20
+              },
+              "end": {
+                "line": 1,
+                "column": 22
+              }
+            }
+          ],
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 19
+          },
+          "end": {
+            "line": 1,
+            "column": 23
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 12
+      },
+      "end": {
+        "line": 1,
+        "column": 23
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 24
+      },
+      "end": {
+        "line": 1,
+        "column": 24
+      }
+    },
+    {
+      "type": "block",
+      "content": [
+        {
+          "type": "space",
+          "content": "\n  ",
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 26
+          },
+          "end": {
+            "line": 2,
+            "column": 2
+          }
+        },
+        {
+          "type": "atrule",
+          "content": [
+            {
+              "type": "atkeyword",
+              "content": [
+                {
+                  "type": "ident",
+                  "content": "content",
+                  "syntax": "scss",
+                  "start": {
+                    "line": 2,
+                    "column": 4
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 10
+                  }
+                }
+              ],
+              "syntax": "scss",
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 2,
+                "column": 10
+              }
+            }
+          ],
+          "syntax": "scss",
+          "start": {
+            "line": 2,
+            "column": 3
+          },
+          "end": {
+            "line": 2,
+            "column": 10
+          }
+        },
+        {
+          "type": "declarationDelimiter",
+          "content": ";",
+          "syntax": "scss",
+          "start": {
+            "line": 2,
+            "column": 11
+          },
+          "end": {
+            "line": 2,
+            "column": 11
+          }
+        },
+        {
+          "type": "space",
+          "content": "\n",
+          "syntax": "scss",
+          "start": {
+            "line": 2,
+            "column": 12
+          },
+          "end": {
+            "line": 2,
+            "column": 12
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 25
+      },
+      "end": {
+        "line": 3,
+        "column": 1
+      }
+    }
+  ],
+  "syntax": "scss",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 3,
+    "column": 1
+  }
+}

--- a/test/scss/atrule/keyframes.9.scss
+++ b/test/scss/atrule/keyframes.9.scss
@@ -1,0 +1,3 @@
+@keyframes :global(foo) {
+  @content;
+}

--- a/test/scss/atrule/test.coffee
+++ b/test/scss/atrule/test.coffee
@@ -41,6 +41,9 @@ describe 'scss/atrule >>', ->
   it 'keyframes.4', -> this.shouldBeOk()
   it 'keyframes.5', -> this.shouldBeOk()
   it 'keyframes.6', -> this.shouldBeOk()
+  it 'keyframes.7', -> this.shouldBeOk()
+  it 'keyframes.8', -> this.shouldBeOk()
+  it 'keyframes.9', -> this.shouldBeOk()
 
   it 'keyframes.interp.0', -> this.shouldBeOk()
   it 'keyframes.interp.1', -> this.shouldBeOk()


### PR DESCRIPTION
This PR fixes #203 (pseudo class keyframes) by adding a check for `pseudoClass` in the `keyframesRule` check.

It also fixes an issue where the following syntax wasn't considered a keyframe atrule (type 4) because a keyframe block was not detected. This has been fixed by removing the requirement of a `keyframesBlock` and by checking that we've reached the end of the block instead. 

```sass
@keyframes foo
  @content

@keyframes :global(foo)
  @content
```

The `Sass` syntax was also missing a `checkAtrule` (`@content`) [line 2836](https://github.com/tonyganch/gonzales-pe/compare/dev...bgriffith:feature/pseudo-class-keyframes?expand=1&w=1#diff-641fa76a7b5d8836c7ba503a0a25db24R2836) in `checkKeyframesBlocks` even though the `getAtrule` was in the `getKeyframesBlocks` function.

Closes #203 
