### PR TITLE
[css|less|sass|scss] Fix case-sensitive keyframe check

### DIFF
--- a/src/css/parse.js
+++ b/src/css/parse.js
@@ -1490,7 +1490,7 @@ function checkKeyframesRule(i) {
   else return 0;
 
   const atruleName = joinValues2(i - l, l);
-  if (atruleName.indexOf('keyframes') === -1) return 0;
+  if (atruleName.toLowerCase().indexOf('keyframes') === -1) return 0;
 
   if (l = checkSC(i)) i += l;
   else return 0;

--- a/src/less/parse.js
+++ b/src/less/parse.js
@@ -2012,7 +2012,7 @@ function checkKeyframesRule(i) {
   else return 0;
 
   const atruleName = joinValues2(i - l, l);
-  if (atruleName.indexOf('keyframes') === -1) return 0;
+  if (atruleName.toLowerCase().indexOf('keyframes') === -1) return 0;
 
   if (l = checkSC(i)) i += l;
   else return 0;

--- a/src/sass/parse.js
+++ b/src/sass/parse.js
@@ -2925,7 +2925,7 @@ function checkKeyframesRule(i) {
   else return 0;
 
   const atruleName = joinValues2(i - l, l);
-  if (atruleName.indexOf('keyframes') === -1) return 0;
+  if (atruleName.toLowerCase().indexOf('keyframes') === -1) return 0;
 
   if (l = checkSC(i)) i += l;
   else return 0;

--- a/src/scss/parse.js
+++ b/src/scss/parse.js
@@ -2436,7 +2436,7 @@ function checkKeyframesRule(i) {
   else return 0;
 
   const atruleName = joinValues2(i - l, l);
-  if (atruleName.indexOf('keyframes') === -1) return 0;
+  if (atruleName.toLowerCase().indexOf('keyframes') === -1) return 0;
 
   if (l = checkSC(i)) i += l;
   else return 0;


### PR DESCRIPTION
Fixes a bug where `Keyframes` was not recognised as a `keyframe` as the check was case-sensitive.