### PR TITLE
[sass] Fix bug with multiline selectors in keyframes

### DIFF
--- a/src/sass/parse.js
+++ b/src/sass/parse.js
@@ -3041,15 +3041,32 @@ function checkKeyframesSelectorsGroup(i) {
   if (l = checkKeyframesSelector(i)) i += l;
   else return 0;
 
-  while (i < tokensLength) {
-    const spaceBefore = checkSC(i);
-    const comma = checkDelim(i + spaceBefore);
-    if (!comma) break;
+  // Check for trailing space
+  if (l = checkSC(i) && tokens[i].type !== TokenType.Newline) i += l;
 
-    const spaceAfter = checkSC(i + spaceBefore + comma);
-    if (l = checkKeyframesSelector(i + spaceBefore + comma + spaceAfter)) {
-      i += spaceBefore + comma + spaceAfter + l;
-    } else break;
+  while (i < tokensLength) {
+    const tempStart = i;
+    let tempIndex = i;
+    let tempLength;
+
+    if (tempLength = checkDelim(tempIndex)) tempIndex += tempLength;
+    else break;
+
+    // Check for maxmimum space usage - 'space', '\n', 'space'
+    if (tempLength = checkSC(tempIndex)) tempIndex += tempLength;
+    if (tempLength = checkSC(tempIndex)) tempIndex += tempLength;
+    if (tempLength = checkSC(tempIndex)) tempIndex += tempLength;
+
+    if (tempLength = checkKeyframesSelector(tempIndex)) tempIndex += tempLength;
+    else break;
+
+    // Check for trailing space
+    if (tempLength = checkSC(tempIndex) &&
+        tokens[tempIndex].type !== TokenType.Newline) {
+      tempIndex += tempLength;
+    }
+
+    i += tempIndex - tempStart;
   }
 
   tokens[start].selectorsGroupEnd = i;
@@ -3067,13 +3084,22 @@ function getKeyframesSelectorsGroup() {
 
   selectorsGroup.push(getKeyframesSelector());
 
+  if (checkSC(pos) && tokens[pos].type !== TokenType.Newline) {
+    selectorsGroup = selectorsGroup.concat(getSC());
+  }
+
   while (pos < selectorsGroupEnd) {
     selectorsGroup = selectorsGroup.concat(
-      getSC(),
       getDelim(),
+      getSC(),
+      getSC(),
       getSC(),
       getKeyframesSelector()
     );
+
+    if (checkSC(pos) && tokens[pos].type !== TokenType.Newline) {
+      selectorsGroup = selectorsGroup.concat(getSC());
+    }
   }
 
   return selectorsGroup;

--- a/test/sass/include/issue-205-1.json
+++ b/test/sass/include/issue-205-1.json
@@ -1,0 +1,704 @@
+{
+  "type": "include",
+  "content": [
+    {
+      "type": "operator",
+      "content": "+",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 1,
+        "column": 1
+      }
+    },
+    {
+      "type": "ident",
+      "content": "keyframes",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 2
+      },
+      "end": {
+        "line": 1,
+        "column": 10
+      }
+    },
+    {
+      "type": "arguments",
+      "content": [
+        {
+          "type": "ident",
+          "content": "loadMoreSpinner",
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 12
+          },
+          "end": {
+            "line": 1,
+            "column": 26
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 11
+      },
+      "end": {
+        "line": 1,
+        "column": 27
+      }
+    },
+    {
+      "type": "space",
+      "content": "\n",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 28
+      },
+      "end": {
+        "line": 1,
+        "column": 28
+      }
+    },
+    {
+      "type": "block",
+      "content": [
+        {
+          "type": "space",
+          "content": "  ",
+          "syntax": "sass",
+          "start": {
+            "line": 2,
+            "column": 1
+          },
+          "end": {
+            "line": 2,
+            "column": 2
+          }
+        },
+        {
+          "type": "ruleset",
+          "content": [
+            {
+              "type": "selector",
+              "content": [
+                {
+                  "type": "keyframesSelector",
+                  "content": [
+                    {
+                      "type": "percentage",
+                      "content": [
+                        {
+                          "type": "number",
+                          "content": "0",
+                          "syntax": "sass",
+                          "start": {
+                            "line": 2,
+                            "column": 3
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 3
+                          }
+                        }
+                      ],
+                      "syntax": "sass",
+                      "start": {
+                        "line": 2,
+                        "column": 3
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 4
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 4
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 2,
+                "column": 4
+              }
+            },
+            {
+              "type": "delimiter",
+              "content": ",",
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 5
+              },
+              "end": {
+                "line": 2,
+                "column": 5
+              }
+            },
+            {
+              "type": "space",
+              "content": " ",
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 6
+              },
+              "end": {
+                "line": 2,
+                "column": 6
+              }
+            },
+            {
+              "type": "selector",
+              "content": [
+                {
+                  "type": "keyframesSelector",
+                  "content": [
+                    {
+                      "type": "percentage",
+                      "content": [
+                        {
+                          "type": "number",
+                          "content": "100",
+                          "syntax": "sass",
+                          "start": {
+                            "line": 2,
+                            "column": 7
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 9
+                          }
+                        }
+                      ],
+                      "syntax": "sass",
+                      "start": {
+                        "line": 2,
+                        "column": 7
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 10
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 7
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 10
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 7
+              },
+              "end": {
+                "line": 2,
+                "column": 10
+              }
+            },
+            {
+              "type": "space",
+              "content": "\n",
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 11
+              },
+              "end": {
+                "line": 2,
+                "column": 11
+              }
+            },
+
+
+            {
+              "type": "block",
+              "content": [
+                {
+                  "type": "space",
+                  "content": "    ",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 3,
+                    "column": 1
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 4
+                  }
+                },
+                {
+                  "type": "include",
+                  "content": [
+                    {
+                      "type": "operator",
+                      "content": "+",
+                      "syntax": "sass",
+                      "start": {
+                        "line": 3,
+                        "column": 5
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 5
+                      }
+                    },
+                    {
+                      "type": "ident",
+                      "content": "transform",
+                      "syntax": "sass",
+                      "start": {
+                        "line": 3,
+                        "column": 6
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 14
+                      }
+                    },
+                    {
+                      "type": "arguments",
+                      "content": [
+                        {
+                          "type": "function",
+                          "content": [
+                            {
+                              "type": "ident",
+                              "content": "rotate",
+                              "syntax": "sass",
+                              "start": {
+                                "line": 3,
+                                "column": 16
+                              },
+                              "end": {
+                                "line": 3,
+                                "column": 21
+                              }
+                            },
+                            {
+                              "type": "arguments",
+                              "content": [
+                                {
+                                  "type": "dimension",
+                                  "content": [
+                                    {
+                                      "type": "number",
+                                      "content": "0",
+                                      "syntax": "sass",
+                                      "start": {
+                                        "line": 3,
+                                        "column": 23
+                                      },
+                                      "end": {
+                                        "line": 3,
+                                        "column": 23
+                                      }
+                                    },
+                                    {
+                                      "type": "ident",
+                                      "content": "deg",
+                                      "syntax": "sass",
+                                      "start": {
+                                        "line": 3,
+                                        "column": 24
+                                      },
+                                      "end": {
+                                        "line": 3,
+                                        "column": 26
+                                      }
+                                    }
+                                  ],
+                                  "syntax": "sass",
+                                  "start": {
+                                    "line": 3,
+                                    "column": 23
+                                  },
+                                  "end": {
+                                    "line": 3,
+                                    "column": 26
+                                  }
+                                }
+                              ],
+                              "syntax": "sass",
+                              "start": {
+                                "line": 3,
+                                "column": 22
+                              },
+                              "end": {
+                                "line": 3,
+                                "column": 27
+                              }
+                            }
+                          ],
+                          "syntax": "sass",
+                          "start": {
+                            "line": 3,
+                            "column": 16
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 27
+                          }
+                        }
+                      ],
+                      "syntax": "sass",
+                      "start": {
+                        "line": 3,
+                        "column": 15
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 28
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 3,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 28
+                  }
+                },
+                {
+                  "type": "declarationDelimiter",
+                  "content": "\n",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 3,
+                    "column": 29
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 29
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 3,
+                "column": 1
+              },
+              "end": {
+                "line": 3,
+                "column": 29
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 2,
+            "column": 3
+          },
+          "end": {
+            "line": 3,
+            "column": 29
+          }
+        },
+        {
+          "type": "space",
+          "content": "  ",
+          "syntax": "sass",
+          "start": {
+            "line": 4,
+            "column": 1
+          },
+          "end": {
+            "line": 4,
+            "column": 2
+          }
+        },
+        {
+          "type": "ruleset",
+          "content": [
+            {
+              "type": "selector",
+              "content": [
+                {
+                  "type": "keyframesSelector",
+                  "content": [
+                    {
+                      "type": "percentage",
+                      "content": [
+                        {
+                          "type": "number",
+                          "content": "50",
+                          "syntax": "sass",
+                          "start": {
+                            "line": 4,
+                            "column": 3
+                          },
+                          "end": {
+                            "line": 4,
+                            "column": 4
+                          }
+                        }
+                      ],
+                      "syntax": "sass",
+                      "start": {
+                        "line": 4,
+                        "column": 3
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 5
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 4,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 5
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 4,
+                "column": 3
+              },
+              "end": {
+                "line": 4,
+                "column": 5
+              }
+            },
+            {
+              "type": "space",
+              "content": "\n",
+              "syntax": "sass",
+              "start": {
+                "line": 4,
+                "column": 6
+              },
+              "end": {
+                "line": 4,
+                "column": 6
+              }
+            },
+            {
+              "type": "block",
+              "content": [
+                {
+                  "type": "space",
+                  "content": "    ",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 5,
+                    "column": 1
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 4
+                  }
+                },
+                {
+                  "type": "include",
+                  "content": [
+                    {
+                      "type": "operator",
+                      "content": "+",
+                      "syntax": "sass",
+                      "start": {
+                        "line": 5,
+                        "column": 5
+                      },
+                      "end": {
+                        "line": 5,
+                        "column": 5
+                      }
+                    },
+                    {
+                      "type": "ident",
+                      "content": "transform",
+                      "syntax": "sass",
+                      "start": {
+                        "line": 5,
+                        "column": 6
+                      },
+                      "end": {
+                        "line": 5,
+                        "column": 14
+                      }
+                    },
+                    {
+                      "type": "arguments",
+                      "content": [
+                        {
+                          "type": "function",
+                          "content": [
+                            {
+                              "type": "ident",
+                              "content": "rotate",
+                              "syntax": "sass",
+                              "start": {
+                                "line": 5,
+                                "column": 16
+                              },
+                              "end": {
+                                "line": 5,
+                                "column": 21
+                              }
+                            },
+                            {
+                              "type": "arguments",
+                              "content": [
+                                {
+                                  "type": "dimension",
+                                  "content": [
+                                    {
+                                      "type": "number",
+                                      "content": "180",
+                                      "syntax": "sass",
+                                      "start": {
+                                        "line": 5,
+                                        "column": 23
+                                      },
+                                      "end": {
+                                        "line": 5,
+                                        "column": 25
+                                      }
+                                    },
+                                    {
+                                      "type": "ident",
+                                      "content": "deg",
+                                      "syntax": "sass",
+                                      "start": {
+                                        "line": 5,
+                                        "column": 26
+                                      },
+                                      "end": {
+                                        "line": 5,
+                                        "column": 28
+                                      }
+                                    }
+                                  ],
+                                  "syntax": "sass",
+                                  "start": {
+                                    "line": 5,
+                                    "column": 23
+                                  },
+                                  "end": {
+                                    "line": 5,
+                                    "column": 28
+                                  }
+                                }
+                              ],
+                              "syntax": "sass",
+                              "start": {
+                                "line": 5,
+                                "column": 22
+                              },
+                              "end": {
+                                "line": 5,
+                                "column": 29
+                              }
+                            }
+                          ],
+                          "syntax": "sass",
+                          "start": {
+                            "line": 5,
+                            "column": 16
+                          },
+                          "end": {
+                            "line": 5,
+                            "column": 29
+                          }
+                        }
+                      ],
+                      "syntax": "sass",
+                      "start": {
+                        "line": 5,
+                        "column": 15
+                      },
+                      "end": {
+                        "line": 5,
+                        "column": 30
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 5,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 30
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 5,
+                "column": 1
+              },
+              "end": {
+                "line": 5,
+                "column": 30
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 4,
+            "column": 3
+          },
+          "end": {
+            "line": 5,
+            "column": 30
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 2,
+        "column": 1
+      },
+      "end": {
+        "line": 5,
+        "column": 30
+      }
+    }
+  ],
+  "syntax": "sass",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 5,
+    "column": 30
+  }
+}

--- a/test/sass/include/issue-205-1.sass
+++ b/test/sass/include/issue-205-1.sass
@@ -1,0 +1,5 @@
++keyframes(loadMoreSpinner)
+  0%, 100%
+    +transform(rotate(0deg))
+  50%
+    +transform(rotate(180deg))

--- a/test/sass/include/issue-205-2.json
+++ b/test/sass/include/issue-205-2.json
@@ -1,0 +1,719 @@
+{
+  "type": "include",
+  "content": [
+    {
+      "type": "operator",
+      "content": "+",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 1,
+        "column": 1
+      }
+    },
+    {
+      "type": "ident",
+      "content": "keyframes",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 2
+      },
+      "end": {
+        "line": 1,
+        "column": 10
+      }
+    },
+    {
+      "type": "arguments",
+      "content": [
+        {
+          "type": "ident",
+          "content": "loadMoreSpinner",
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 12
+          },
+          "end": {
+            "line": 1,
+            "column": 26
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 11
+      },
+      "end": {
+        "line": 1,
+        "column": 27
+      }
+    },
+    {
+      "type": "space",
+      "content": "\n",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 28
+      },
+      "end": {
+        "line": 1,
+        "column": 28
+      }
+    },
+    {
+      "type": "block",
+      "content": [
+        {
+          "type": "space",
+          "content": "  ",
+          "syntax": "sass",
+          "start": {
+            "line": 2,
+            "column": 1
+          },
+          "end": {
+            "line": 2,
+            "column": 2
+          }
+        },
+        {
+          "type": "ruleset",
+          "content": [
+            {
+              "type": "selector",
+              "content": [
+                {
+                  "type": "keyframesSelector",
+                  "content": [
+                    {
+                      "type": "percentage",
+                      "content": [
+                        {
+                          "type": "number",
+                          "content": "0",
+                          "syntax": "sass",
+                          "start": {
+                            "line": 2,
+                            "column": 3
+                          },
+                          "end": {
+                            "line": 2,
+                            "column": 3
+                          }
+                        }
+                      ],
+                      "syntax": "sass",
+                      "start": {
+                        "line": 2,
+                        "column": 3
+                      },
+                      "end": {
+                        "line": 2,
+                        "column": 4
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 4
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 2,
+                "column": 4
+              }
+            },
+            {
+              "type": "delimiter",
+              "content": ",",
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 5
+              },
+              "end": {
+                "line": 2,
+                "column": 5
+              }
+            },
+            {
+              "type": "space",
+              "content": "\n",
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 6
+              },
+              "end": {
+                "line": 2,
+                "column": 6
+              }
+            },
+            {
+              "type": "space",
+              "content": "  ",
+              "syntax": "sass",
+              "start": {
+                "line": 3,
+                "column": 1
+              },
+              "end": {
+                "line": 3,
+                "column": 2
+              }
+            },
+
+
+            {
+              "type": "selector",
+              "content": [
+                {
+                  "type": "keyframesSelector",
+                  "content": [
+                    {
+                      "type": "percentage",
+                      "content": [
+                        {
+                          "type": "number",
+                          "content": "100",
+                          "syntax": "sass",
+                          "start": {
+                            "line": 3,
+                            "column": 3
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 5
+                          }
+                        }
+                      ],
+                      "syntax": "sass",
+                      "start": {
+                        "line": 3,
+                        "column": 3
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 6
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 3,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 3,
+                    "column": 6
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 3,
+                "column": 3
+              },
+              "end": {
+                "line": 3,
+                "column": 6
+              }
+            },
+            {
+              "type": "space",
+              "content": "\n",
+              "syntax": "sass",
+              "start": {
+                "line": 3,
+                "column": 7
+              },
+              "end": {
+                "line": 3,
+                "column": 7
+              }
+            },
+
+
+            {
+              "type": "block",
+              "content": [
+                {
+                  "type": "space",
+                  "content": "    ",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 4,
+                    "column": 1
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 4
+                  }
+                },
+                {
+                  "type": "include",
+                  "content": [
+                    {
+                      "type": "operator",
+                      "content": "+",
+                      "syntax": "sass",
+                      "start": {
+                        "line": 4,
+                        "column": 5
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 5
+                      }
+                    },
+                    {
+                      "type": "ident",
+                      "content": "transform",
+                      "syntax": "sass",
+                      "start": {
+                        "line": 4,
+                        "column": 6
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 14
+                      }
+                    },
+                    {
+                      "type": "arguments",
+                      "content": [
+                        {
+                          "type": "function",
+                          "content": [
+                            {
+                              "type": "ident",
+                              "content": "rotate",
+                              "syntax": "sass",
+                              "start": {
+                                "line": 4,
+                                "column": 16
+                              },
+                              "end": {
+                                "line": 4,
+                                "column": 21
+                              }
+                            },
+                            {
+                              "type": "arguments",
+                              "content": [
+                                {
+                                  "type": "dimension",
+                                  "content": [
+                                    {
+                                      "type": "number",
+                                      "content": "0",
+                                      "syntax": "sass",
+                                      "start": {
+                                        "line": 4,
+                                        "column": 23
+                                      },
+                                      "end": {
+                                        "line": 4,
+                                        "column": 23
+                                      }
+                                    },
+                                    {
+                                      "type": "ident",
+                                      "content": "deg",
+                                      "syntax": "sass",
+                                      "start": {
+                                        "line": 4,
+                                        "column": 24
+                                      },
+                                      "end": {
+                                        "line": 4,
+                                        "column": 26
+                                      }
+                                    }
+                                  ],
+                                  "syntax": "sass",
+                                  "start": {
+                                    "line": 4,
+                                    "column": 23
+                                  },
+                                  "end": {
+                                    "line": 4,
+                                    "column": 26
+                                  }
+                                }
+                              ],
+                              "syntax": "sass",
+                              "start": {
+                                "line": 4,
+                                "column": 22
+                              },
+                              "end": {
+                                "line": 4,
+                                "column": 27
+                              }
+                            }
+                          ],
+                          "syntax": "sass",
+                          "start": {
+                            "line": 4,
+                            "column": 16
+                          },
+                          "end": {
+                            "line": 4,
+                            "column": 27
+                          }
+                        }
+                      ],
+                      "syntax": "sass",
+                      "start": {
+                        "line": 4,
+                        "column": 15
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 28
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 4,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 28
+                  }
+                },
+                {
+                  "type": "declarationDelimiter",
+                  "content": "\n",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 4,
+                    "column": 29
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 29
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 4,
+                "column": 1
+              },
+              "end": {
+                "line": 4,
+                "column": 29
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 2,
+            "column": 3
+          },
+          "end": {
+            "line": 4,
+            "column": 29
+          }
+        },
+        {
+          "type": "space",
+          "content": "  ",
+          "syntax": "sass",
+          "start": {
+            "line": 5,
+            "column": 1
+          },
+          "end": {
+            "line": 5,
+            "column": 2
+          }
+        },
+        {
+          "type": "ruleset",
+          "content": [
+            {
+              "type": "selector",
+              "content": [
+                {
+                  "type": "keyframesSelector",
+                  "content": [
+                    {
+                      "type": "percentage",
+                      "content": [
+                        {
+                          "type": "number",
+                          "content": "50",
+                          "syntax": "sass",
+                          "start": {
+                            "line": 5,
+                            "column": 3
+                          },
+                          "end": {
+                            "line": 5,
+                            "column": 4
+                          }
+                        }
+                      ],
+                      "syntax": "sass",
+                      "start": {
+                        "line": 5,
+                        "column": 3
+                      },
+                      "end": {
+                        "line": 5,
+                        "column": 5
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 5,
+                    "column": 3
+                  },
+                  "end": {
+                    "line": 5,
+                    "column": 5
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 5,
+                "column": 3
+              },
+              "end": {
+                "line": 5,
+                "column": 5
+              }
+            },
+            {
+              "type": "space",
+              "content": "\n",
+              "syntax": "sass",
+              "start": {
+                "line": 5,
+                "column": 6
+              },
+              "end": {
+                "line": 5,
+                "column": 6
+              }
+            },
+            {
+              "type": "block",
+              "content": [
+                {
+                  "type": "space",
+                  "content": "    ",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 6,
+                    "column": 1
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 4
+                  }
+                },
+                {
+                  "type": "include",
+                  "content": [
+                    {
+                      "type": "operator",
+                      "content": "+",
+                      "syntax": "sass",
+                      "start": {
+                        "line": 6,
+                        "column": 5
+                      },
+                      "end": {
+                        "line": 6,
+                        "column": 5
+                      }
+                    },
+                    {
+                      "type": "ident",
+                      "content": "transform",
+                      "syntax": "sass",
+                      "start": {
+                        "line": 6,
+                        "column": 6
+                      },
+                      "end": {
+                        "line": 6,
+                        "column": 14
+                      }
+                    },
+                    {
+                      "type": "arguments",
+                      "content": [
+                        {
+                          "type": "function",
+                          "content": [
+                            {
+                              "type": "ident",
+                              "content": "rotate",
+                              "syntax": "sass",
+                              "start": {
+                                "line": 6,
+                                "column": 16
+                              },
+                              "end": {
+                                "line": 6,
+                                "column": 21
+                              }
+                            },
+                            {
+                              "type": "arguments",
+                              "content": [
+                                {
+                                  "type": "dimension",
+                                  "content": [
+                                    {
+                                      "type": "number",
+                                      "content": "180",
+                                      "syntax": "sass",
+                                      "start": {
+                                        "line": 6,
+                                        "column": 23
+                                      },
+                                      "end": {
+                                        "line": 6,
+                                        "column": 25
+                                      }
+                                    },
+                                    {
+                                      "type": "ident",
+                                      "content": "deg",
+                                      "syntax": "sass",
+                                      "start": {
+                                        "line": 6,
+                                        "column": 26
+                                      },
+                                      "end": {
+                                        "line": 6,
+                                        "column": 28
+                                      }
+                                    }
+                                  ],
+                                  "syntax": "sass",
+                                  "start": {
+                                    "line": 6,
+                                    "column": 23
+                                  },
+                                  "end": {
+                                    "line": 6,
+                                    "column": 28
+                                  }
+                                }
+                              ],
+                              "syntax": "sass",
+                              "start": {
+                                "line": 6,
+                                "column": 22
+                              },
+                              "end": {
+                                "line": 6,
+                                "column": 29
+                              }
+                            }
+                          ],
+                          "syntax": "sass",
+                          "start": {
+                            "line": 6,
+                            "column": 16
+                          },
+                          "end": {
+                            "line": 6,
+                            "column": 29
+                          }
+                        }
+                      ],
+                      "syntax": "sass",
+                      "start": {
+                        "line": 6,
+                        "column": 15
+                      },
+                      "end": {
+                        "line": 6,
+                        "column": 30
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 6,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 6,
+                    "column": 30
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 6,
+                "column": 1
+              },
+              "end": {
+                "line": 6,
+                "column": 30
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 5,
+            "column": 3
+          },
+          "end": {
+            "line": 6,
+            "column": 30
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 2,
+        "column": 1
+      },
+      "end": {
+        "line": 6,
+        "column": 30
+      }
+    }
+  ],
+  "syntax": "sass",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 6,
+    "column": 30
+  }
+}

--- a/test/sass/include/issue-205-2.sass
+++ b/test/sass/include/issue-205-2.sass
@@ -1,0 +1,6 @@
++keyframes(loadMoreSpinner)
+  0%,
+  100%
+    +transform(rotate(0deg))
+  50%
+    +transform(rotate(180deg))

--- a/test/sass/include/test.coffee
+++ b/test/sass/include/test.coffee
@@ -13,3 +13,5 @@ describe 'sass/include >>', ->
   it '11', -> this.shouldBeOk()
 
   it 'issue-205', -> this.shouldBeOk()
+  it 'issue-205-1', -> this.shouldBeOk()
+  it 'issue-205-2', -> this.shouldBeOk()


### PR DESCRIPTION
Fixes a parse issue with multiline selectors in keyframes highlighted within the following discussion (https://github.com/sasstools/sass-lint/issues/797)

```sass
@keyframes shadow
  0%,
  20%
    background-color: rgba(0, 0, 0, 0)
    transform: scale(0)
```

Also modified to allow for trailing whitespace after selector if it exists