### PR TITLE
[css|sass|scss] Add @apply custom property support

### DIFF
--- a/src/sass/parse.js
+++ b/src/sass/parse.js
@@ -589,13 +589,15 @@ function checkAtrule(i) {
 
   // If token is part of an @-rule, save the rule's type to token.
   // @keyframes:
-  if (l = checkKeyframesRule(i)) tokens[i].atrule_type = 4;
+  if (l = checkKeyframesRule(i)) tokens[i].atrule_type = 1;
+  // @apply --custom-property:
+  else if (l = checkApplyRule(i)) tokens[i].atrule_type = 2;
   // @-rule with ruleset:
-  else if (l = checkAtruler(i)) tokens[i].atrule_type = 1;
+  else if (l = checkAtruler(i)) tokens[i].atrule_type = 3;
   // Block @-rule:
-  else if (l = checkAtruleb(i)) tokens[i].atrule_type = 2;
+  else if (l = checkAtruleb(i)) tokens[i].atrule_type = 4;
   // Single-line @-rule:
-  else if (l = checkAtrules(i)) tokens[i].atrule_type = 3;
+  else if (l = checkAtrules(i)) tokens[i].atrule_type = 5;
   else return 0;
 
   // If token is part of an @-rule, save the rule's length to token:
@@ -612,10 +614,11 @@ function checkAtrule(i) {
 function getAtrule() {
   const childType = tokens[pos].atrule_type;
 
-  if (childType === 1) return getAtruler(); // @-rule with ruleset
-  if (childType === 2) return getAtruleb(); // Block @-rule
-  if (childType === 3) return getAtrules(); // Single-line @-rule
-  if (childType === 4) return getKeyframesRule();
+  if (childType === 1) return getKeyframesRule();
+  if (childType === 2) return getApplyRule();
+  if (childType === 3) return getAtruler(); // @-rule with ruleset
+  if (childType === 4) return getAtruleb(); // Block @-rule
+  if (childType === 5) return getAtrules(); // Single-line @-rule
 }
 
 /**
@@ -786,6 +789,47 @@ function getAtrules() {
 }
 
 /**
+ * @param {Number} i Token's index number
+ * @returns {Number}
+ */
+function checkApplyRule(i) {
+  const start = i;
+  let l;
+
+  if (i >= tokensLength) return 0;
+
+  if (l = checkAtkeyword(i)) i += l;
+  else return 0;
+
+  const atruleName = joinValues2(i - l, l);
+  if (atruleName.toLowerCase().indexOf('apply') === -1) return 0;
+
+  if (l = checkSC(i)) i += l;
+
+  if (l = checkCustomProperty(i)) i += l;
+  else return 0;
+
+  return i - start;
+}
+
+/**
+ * @returns {Node}
+ */
+function getApplyRule() {
+  const type = NodeType.AtruleType;
+  const token = tokens[pos];
+  const line = token.ln;
+  const column = token.col;
+  let content = [].concat(
+    getAtkeyword(),
+    getSC(),
+    getCustomProperty()
+  );
+
+  return newNode(type, content, line, column);
+}
+
+/**
  * Checks if token is part of a block (e.g. `{...}`).
  *
  * @param {number} i Token's index number
@@ -874,7 +918,7 @@ function checkBlockdecl1(i) {
       [2, 4, 6, 8].indexOf(tokens[start].include_type) === -1) return 0;
 
   if (tokens[start].bd_kind === 6 &&
-      tokens[start].atrule_type === 3) return 0;
+      tokens[start].atrule_type === 5) return 0;
 
   while (i < tokensLength) {
     if (l = checkDeclDelim(i))

--- a/src/scss/parse.js
+++ b/src/scss/parse.js
@@ -557,13 +557,15 @@ function checkAtrule(i) {
 
   // If token is part of an @-rule, save the rule's type to token.
   // @keyframes:
-  if (l = checkKeyframesRule(i)) tokens[i].atrule_type = 4;
+  if (l = checkKeyframesRule(i)) tokens[i].atrule_type = 1;
+  // @apply --custom-property:
+  else if (l = checkApplyRule(i)) tokens[i].atrule_type = 2;
   // @-rule with ruleset:
-  else if (l = checkAtruler(i)) tokens[i].atrule_type = 1;
+  else if (l = checkAtruler(i)) tokens[i].atrule_type = 3;
   // Block @-rule:
-  else if (l = checkAtruleb(i)) tokens[i].atrule_type = 2;
+  else if (l = checkAtruleb(i)) tokens[i].atrule_type = 4;
   // Single-line @-rule:
-  else if (l = checkAtrules(i)) tokens[i].atrule_type = 3;
+  else if (l = checkAtrules(i)) tokens[i].atrule_type = 5;
   else return 0;
 
   // If token is part of an @-rule, save the rule's length to token:
@@ -579,10 +581,11 @@ function checkAtrule(i) {
 function getAtrule() {
   const childType = tokens[pos].atrule_type;
 
-  if (childType === 1) return getAtruler(); // @-rule with ruleset
-  if (childType === 2) return getAtruleb(); // Block @-rule
-  if (childType === 3) return getAtrules(); // Single-line @-rule
-  if (childType === 4) return getKeyframesRule();
+  if (childType === 1) return getKeyframesRule();
+  if (childType === 2) return getApplyRule();
+  if (childType === 3) return getAtruler(); // @-rule with ruleset
+  if (childType === 4) return getAtruleb(); // Block @-rule
+  if (childType === 5) return getAtrules(); // Single-line @-rule
 }
 
 /**
@@ -759,6 +762,47 @@ function getAtrules() {
   const content = [].concat(
     getAtkeyword(),
     getTsets()
+  );
+
+  return newNode(type, content, line, column);
+}
+
+/**
+ * @param {Number} i Token's index number
+ * @returns {Number}
+ */
+function checkApplyRule(i) {
+  const start = i;
+  let l;
+
+  if (i >= tokensLength) return 0;
+
+  if (l = checkAtkeyword(i)) i += l;
+  else return 0;
+
+  const atruleName = joinValues2(i - l, l);
+  if (atruleName.toLowerCase().indexOf('apply') === -1) return 0;
+
+  if (l = checkSC(i)) i += l;
+
+  if (l = checkCustomProperty(i)) i += l;
+  else return 0;
+
+  return i - start;
+}
+
+/**
+ * @returns {Node}
+ */
+function getApplyRule() {
+  const type = NodeType.AtruleType;
+  const token = tokens[pos];
+  const line = token.ln;
+  const column = token.col;
+  let content = [].concat(
+    getAtkeyword(),
+    getSC(),
+    getCustomProperty()
   );
 
   return newNode(type, content, line, column);

--- a/test/css/atrule/14.css
+++ b/test/css/atrule/14.css
@@ -1,0 +1,1 @@
+@apply --custom-property

--- a/test/css/atrule/14.json
+++ b/test/css/atrule/14.json
@@ -1,0 +1,81 @@
+{
+  "type": "atrule",
+  "content": [
+    {
+      "type": "atkeyword",
+      "content": [
+        {
+          "type": "ident",
+          "content": "apply",
+          "syntax": "css",
+          "start": {
+            "line": 1,
+            "column": 2
+          },
+          "end": {
+            "line": 1,
+            "column": 6
+          }
+        }
+      ],
+      "syntax": "css",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 1,
+        "column": 6
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "css",
+      "start": {
+        "line": 1,
+        "column": 7
+      },
+      "end": {
+        "line": 1,
+        "column": 7
+      }
+    },
+    {
+      "type": "customProperty",
+      "content": [
+        {
+          "type": "ident",
+          "content": "custom-property",
+          "syntax": "css",
+          "start": {
+            "line": 1,
+            "column": 10
+          },
+          "end": {
+            "line": 1,
+            "column": 24
+          }
+        }
+      ],
+      "syntax": "css",
+      "start": {
+        "line": 1,
+        "column": 8
+      },
+      "end": {
+        "line": 1,
+        "column": 24
+      }
+    }
+  ],
+  "syntax": "css",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 1,
+    "column": 24
+  }
+}

--- a/test/css/atrule/test.coffee
+++ b/test/css/atrule/test.coffee
@@ -14,6 +14,7 @@ describe 'css/atrule >>', ->
   it '11', -> this.shouldBeOk()
   it '12', -> this.shouldBeOk()
   it '13', -> this.shouldBeOk()
+  it '14', -> this.shouldBeOk()
 
   it 'c.0', -> this.shouldBeOk()
   it 'c.1', -> this.shouldBeOk()

--- a/test/css/ruleset/9.css
+++ b/test/css/ruleset/9.css
@@ -1,0 +1,5 @@
+:root {
+  --foo-bar: {
+    content: 'foobar';
+  }
+}

--- a/test/css/ruleset/9.json
+++ b/test/css/ruleset/9.json
@@ -1,0 +1,336 @@
+{
+  "type": "ruleset",
+  "content": [
+    {
+      "type": "selector",
+      "content": [
+        {
+          "type": "pseudoClass",
+          "content": [
+            {
+              "type": "ident",
+              "content": "root",
+              "syntax": "css",
+              "start": {
+                "line": 1,
+                "column": 2
+              },
+              "end": {
+                "line": 1,
+                "column": 5
+              }
+            }
+          ],
+          "syntax": "css",
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 1,
+            "column": 5
+          }
+        }
+      ],
+      "syntax": "css",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 1,
+        "column": 5
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "css",
+      "start": {
+        "line": 1,
+        "column": 6
+      },
+      "end": {
+        "line": 1,
+        "column": 6
+      }
+    },
+    {
+      "type": "block",
+      "content": [
+        {
+          "type": "space",
+          "content": "\n  ",
+          "syntax": "css",
+          "start": {
+            "line": 1,
+            "column": 8
+          },
+          "end": {
+            "line": 2,
+            "column": 2
+          }
+        },
+        {
+          "type": "declaration",
+          "content": [
+            {
+              "type": "customProperty",
+              "content": [
+                {
+                  "type": "ident",
+                  "content": "foo-bar",
+                  "syntax": "css",
+                  "start": {
+                    "line": 2,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 11
+                  }
+                }
+              ],
+              "syntax": "css",
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 2,
+                "column": 11
+              }
+            },
+            {
+              "type": "propertyDelimiter",
+              "content": ":",
+              "syntax": "css",
+              "start": {
+                "line": 2,
+                "column": 12
+              },
+              "end": {
+                "line": 2,
+                "column": 12
+              }
+            },
+            {
+              "type": "space",
+              "content": " ",
+              "syntax": "css",
+              "start": {
+                "line": 2,
+                "column": 13
+              },
+              "end": {
+                "line": 2,
+                "column": 13
+              }
+            },
+            {
+              "type": "value",
+              "content": [
+                {
+                  "type": "block",
+                  "content": [
+                    {
+                      "type": "space",
+                      "content": "\n    ",
+                      "syntax": "css",
+                      "start": {
+                        "line": 2,
+                        "column": 15
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 4
+                      }
+                    },
+                    {
+                      "type": "declaration",
+                      "content": [
+                        {
+                          "type": "property",
+                          "content": [
+                            {
+                              "type": "ident",
+                              "content": "content",
+                              "syntax": "css",
+                              "start": {
+                                "line": 3,
+                                "column": 5
+                              },
+                              "end": {
+                                "line": 3,
+                                "column": 11
+                              }
+                            }
+                          ],
+                          "syntax": "css",
+                          "start": {
+                            "line": 3,
+                            "column": 5
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 11
+                          }
+                        },
+                        {
+                          "type": "propertyDelimiter",
+                          "content": ":",
+                          "syntax": "css",
+                          "start": {
+                            "line": 3,
+                            "column": 12
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 12
+                          }
+                        },
+                        {
+                          "type": "space",
+                          "content": " ",
+                          "syntax": "css",
+                          "start": {
+                            "line": 3,
+                            "column": 13
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 13
+                          }
+                        },
+                        {
+                          "type": "value",
+                          "content": [
+                            {
+                              "type": "string",
+                              "content": "'foobar'",
+                              "syntax": "css",
+                              "start": {
+                                "line": 3,
+                                "column": 14
+                              },
+                              "end": {
+                                "line": 3,
+                                "column": 21
+                              }
+                            }
+                          ],
+                          "syntax": "css",
+                          "start": {
+                            "line": 3,
+                            "column": 14
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 21
+                          }
+                        }
+                      ],
+                      "syntax": "css",
+                      "start": {
+                        "line": 3,
+                        "column": 5
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 21
+                      }
+                    },
+                    {
+                      "type": "declarationDelimiter",
+                      "content": ";",
+                      "syntax": "css",
+                      "start": {
+                        "line": 3,
+                        "column": 22
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 22
+                      }
+                    },
+                    {
+                      "type": "space",
+                      "content": "\n  ",
+                      "syntax": "css",
+                      "start": {
+                        "line": 3,
+                        "column": 23
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 2
+                      }
+                    }
+                  ],
+                  "syntax": "css",
+                  "start": {
+                    "line": 2,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 3
+                  }
+                }
+              ],
+              "syntax": "css",
+              "start": {
+                "line": 2,
+                "column": 14
+              },
+              "end": {
+                "line": 4,
+                "column": 3
+              }
+            }
+          ],
+          "syntax": "css",
+          "start": {
+            "line": 2,
+            "column": 3
+          },
+          "end": {
+            "line": 4,
+            "column": 3
+          }
+        },
+        {
+          "type": "space",
+          "content": "\n",
+          "syntax": "css",
+          "start": {
+            "line": 4,
+            "column": 4
+          },
+          "end": {
+            "line": 4,
+            "column": 4
+          }
+        }
+      ],
+      "syntax": "css",
+      "start": {
+        "line": 1,
+        "column": 7
+      },
+      "end": {
+        "line": 5,
+        "column": 1
+      }
+    }
+  ],
+  "syntax": "css",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 5,
+    "column": 1
+  }
+}

--- a/test/css/ruleset/test.coffee
+++ b/test/css/ruleset/test.coffee
@@ -9,6 +9,7 @@ describe 'css/ruleset >>', ->
   it '6', -> this.shouldBeOk()
   it '7', -> this.shouldBeOk()
   it '8', -> this.shouldBeOk()
+  it '9', -> this.shouldBeOk()
 
   it 'c.0', -> this.shouldBeOk()
   it 'c.1', -> this.shouldBeOk()

--- a/test/sass/atrule/14.json
+++ b/test/sass/atrule/14.json
@@ -1,0 +1,81 @@
+{
+  "type": "atrule",
+  "content": [
+    {
+      "type": "atkeyword",
+      "content": [
+        {
+          "type": "ident",
+          "content": "apply",
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 2
+          },
+          "end": {
+            "line": 1,
+            "column": 6
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 1,
+        "column": 6
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 7
+      },
+      "end": {
+        "line": 1,
+        "column": 7
+      }
+    },
+    {
+      "type": "customProperty",
+      "content": [
+        {
+          "type": "ident",
+          "content": "custom-property",
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 10
+          },
+          "end": {
+            "line": 1,
+            "column": 24
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 8
+      },
+      "end": {
+        "line": 1,
+        "column": 24
+      }
+    }
+  ],
+  "syntax": "sass",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 1,
+    "column": 24
+  }
+}

--- a/test/sass/atrule/14.sass
+++ b/test/sass/atrule/14.sass
@@ -1,0 +1,1 @@
+@apply --custom-property

--- a/test/sass/atrule/test.coffee
+++ b/test/sass/atrule/test.coffee
@@ -14,6 +14,7 @@ describe 'sass/atrule >>', ->
   it '11', -> this.shouldBeOk()
   it '12', -> this.shouldBeOk()
   it '13', -> this.shouldBeOk()
+  it '14', -> this.shouldBeOk()
 
   it 's.0', -> this.shouldBeOk()
 

--- a/test/sass/ruleset/11.json
+++ b/test/sass/ruleset/11.json
@@ -44,7 +44,7 @@
     },
     {
       "type": "space",
-      "content": " ",
+      "content": "\n",
       "syntax": "sass",
       "start": {
         "line": 1,
@@ -60,11 +60,11 @@
       "content": [
         {
           "type": "space",
-          "content": "\n  ",
+          "content": "  ",
           "syntax": "sass",
           "start": {
-            "line": 1,
-            "column": 8
+            "line": 2,
+            "column": 1
           },
           "end": {
             "line": 2,
@@ -116,7 +116,7 @@
             },
             {
               "type": "space",
-              "content": " ",
+              "content": "\n",
               "syntax": "sass",
               "start": {
                 "line": 2,
@@ -135,11 +135,11 @@
                   "content": [
                     {
                       "type": "space",
-                      "content": "\n    ",
+                      "content": "    ",
                       "syntax": "sass",
                       "start": {
-                        "line": 2,
-                        "column": 15
+                        "line": 3,
+                        "column": 1
                       },
                       "end": {
                         "line": 3,
@@ -239,53 +239,27 @@
                         "line": 3,
                         "column": 21
                       }
-                    },
-                    {
-                      "type": "declarationDelimiter",
-                      "content": ";",
-                      "syntax": "sass",
-                      "start": {
-                        "line": 3,
-                        "column": 22
-                      },
-                      "end": {
-                        "line": 3,
-                        "column": 22
-                      }
-                    },
-                    {
-                      "type": "space",
-                      "content": "\n  ",
-                      "syntax": "sass",
-                      "start": {
-                        "line": 3,
-                        "column": 23
-                      },
-                      "end": {
-                        "line": 4,
-                        "column": 2
-                      }
                     }
                   ],
                   "syntax": "sass",
                   "start": {
-                    "line": 2,
-                    "column": 14
+                    "line": 3,
+                    "column": 1
                   },
                   "end": {
-                    "line": 4,
-                    "column": 3
+                    "line": 3,
+                    "column": 21
                   }
                 }
               ],
               "syntax": "sass",
               "start": {
-                "line": 2,
-                "column": 14
+                "line": 3,
+                "column": 1
               },
               "end": {
-                "line": 4,
-                "column": 3
+                "line": 3,
+                "column": 21
               }
             }
           ],
@@ -295,32 +269,19 @@
             "column": 3
           },
           "end": {
-            "line": 4,
-            "column": 3
-          }
-        },
-        {
-          "type": "space",
-          "content": "\n",
-          "syntax": "sass",
-          "start": {
-            "line": 4,
-            "column": 4
-          },
-          "end": {
-            "line": 4,
-            "column": 4
+            "line": 3,
+            "column": 21
           }
         }
       ],
       "syntax": "sass",
       "start": {
-        "line": 1,
-        "column": 7
+        "line": 2,
+        "column": 1
       },
       "end": {
-        "line": 5,
-        "column": 1
+        "line": 3,
+        "column": 21
       }
     }
   ],
@@ -330,7 +291,7 @@
     "column": 1
   },
   "end": {
-    "line": 5,
-    "column": 1
+    "line": 3,
+    "column": 21
   }
 }

--- a/test/sass/ruleset/11.json
+++ b/test/sass/ruleset/11.json
@@ -1,0 +1,336 @@
+{
+  "type": "ruleset",
+  "content": [
+    {
+      "type": "selector",
+      "content": [
+        {
+          "type": "pseudoClass",
+          "content": [
+            {
+              "type": "ident",
+              "content": "root",
+              "syntax": "sass",
+              "start": {
+                "line": 1,
+                "column": 2
+              },
+              "end": {
+                "line": 1,
+                "column": 5
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 1,
+            "column": 5
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 1,
+        "column": 5
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 6
+      },
+      "end": {
+        "line": 1,
+        "column": 6
+      }
+    },
+    {
+      "type": "block",
+      "content": [
+        {
+          "type": "space",
+          "content": "\n  ",
+          "syntax": "sass",
+          "start": {
+            "line": 1,
+            "column": 8
+          },
+          "end": {
+            "line": 2,
+            "column": 2
+          }
+        },
+        {
+          "type": "declaration",
+          "content": [
+            {
+              "type": "customProperty",
+              "content": [
+                {
+                  "type": "ident",
+                  "content": "foo-bar",
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 11
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 2,
+                "column": 11
+              }
+            },
+            {
+              "type": "propertyDelimiter",
+              "content": ":",
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 12
+              },
+              "end": {
+                "line": 2,
+                "column": 12
+              }
+            },
+            {
+              "type": "space",
+              "content": " ",
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 13
+              },
+              "end": {
+                "line": 2,
+                "column": 13
+              }
+            },
+            {
+              "type": "value",
+              "content": [
+                {
+                  "type": "block",
+                  "content": [
+                    {
+                      "type": "space",
+                      "content": "\n    ",
+                      "syntax": "sass",
+                      "start": {
+                        "line": 2,
+                        "column": 15
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 4
+                      }
+                    },
+                    {
+                      "type": "declaration",
+                      "content": [
+                        {
+                          "type": "property",
+                          "content": [
+                            {
+                              "type": "ident",
+                              "content": "content",
+                              "syntax": "sass",
+                              "start": {
+                                "line": 3,
+                                "column": 5
+                              },
+                              "end": {
+                                "line": 3,
+                                "column": 11
+                              }
+                            }
+                          ],
+                          "syntax": "sass",
+                          "start": {
+                            "line": 3,
+                            "column": 5
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 11
+                          }
+                        },
+                        {
+                          "type": "propertyDelimiter",
+                          "content": ":",
+                          "syntax": "sass",
+                          "start": {
+                            "line": 3,
+                            "column": 12
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 12
+                          }
+                        },
+                        {
+                          "type": "space",
+                          "content": " ",
+                          "syntax": "sass",
+                          "start": {
+                            "line": 3,
+                            "column": 13
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 13
+                          }
+                        },
+                        {
+                          "type": "value",
+                          "content": [
+                            {
+                              "type": "string",
+                              "content": "'foobar'",
+                              "syntax": "sass",
+                              "start": {
+                                "line": 3,
+                                "column": 14
+                              },
+                              "end": {
+                                "line": 3,
+                                "column": 21
+                              }
+                            }
+                          ],
+                          "syntax": "sass",
+                          "start": {
+                            "line": 3,
+                            "column": 14
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 21
+                          }
+                        }
+                      ],
+                      "syntax": "sass",
+                      "start": {
+                        "line": 3,
+                        "column": 5
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 21
+                      }
+                    },
+                    {
+                      "type": "declarationDelimiter",
+                      "content": ";",
+                      "syntax": "sass",
+                      "start": {
+                        "line": 3,
+                        "column": 22
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 22
+                      }
+                    },
+                    {
+                      "type": "space",
+                      "content": "\n  ",
+                      "syntax": "sass",
+                      "start": {
+                        "line": 3,
+                        "column": 23
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 2
+                      }
+                    }
+                  ],
+                  "syntax": "sass",
+                  "start": {
+                    "line": 2,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 3
+                  }
+                }
+              ],
+              "syntax": "sass",
+              "start": {
+                "line": 2,
+                "column": 14
+              },
+              "end": {
+                "line": 4,
+                "column": 3
+              }
+            }
+          ],
+          "syntax": "sass",
+          "start": {
+            "line": 2,
+            "column": 3
+          },
+          "end": {
+            "line": 4,
+            "column": 3
+          }
+        },
+        {
+          "type": "space",
+          "content": "\n",
+          "syntax": "sass",
+          "start": {
+            "line": 4,
+            "column": 4
+          },
+          "end": {
+            "line": 4,
+            "column": 4
+          }
+        }
+      ],
+      "syntax": "sass",
+      "start": {
+        "line": 1,
+        "column": 7
+      },
+      "end": {
+        "line": 5,
+        "column": 1
+      }
+    }
+  ],
+  "syntax": "sass",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 5,
+    "column": 1
+  }
+}

--- a/test/sass/ruleset/11.sass
+++ b/test/sass/ruleset/11.sass
@@ -1,5 +1,3 @@
-:root {
-  --foo-bar: {
-    content: 'foobar';
-  }
-}
+:root
+  --foo-bar:
+    content: 'foobar'

--- a/test/sass/ruleset/11.sass
+++ b/test/sass/ruleset/11.sass
@@ -1,0 +1,5 @@
+:root {
+  --foo-bar: {
+    content: 'foobar';
+  }
+}

--- a/test/sass/ruleset/test.coffee
+++ b/test/sass/ruleset/test.coffee
@@ -11,6 +11,7 @@ describe 'sass/ruleset >>', ->
   it '8', -> this.shouldBeOk()
   it '9', -> this.shouldBeOk()
   it '10', -> this.shouldBeOk()
+  it '11', -> this.shouldBeOk()
 
   it 'color.ident.0', -> this.shouldBeOk()
   it 'color.ident.1', -> this.shouldBeOk()

--- a/test/scss/atrule/14.json
+++ b/test/scss/atrule/14.json
@@ -1,0 +1,81 @@
+{
+  "type": "atrule",
+  "content": [
+    {
+      "type": "atkeyword",
+      "content": [
+        {
+          "type": "ident",
+          "content": "apply",
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 2
+          },
+          "end": {
+            "line": 1,
+            "column": 6
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 1,
+        "column": 6
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 7
+      },
+      "end": {
+        "line": 1,
+        "column": 7
+      }
+    },
+    {
+      "type": "customProperty",
+      "content": [
+        {
+          "type": "ident",
+          "content": "custom-property",
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 10
+          },
+          "end": {
+            "line": 1,
+            "column": 24
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 8
+      },
+      "end": {
+        "line": 1,
+        "column": 24
+      }
+    }
+  ],
+  "syntax": "scss",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 1,
+    "column": 24
+  }
+}

--- a/test/scss/atrule/14.scss
+++ b/test/scss/atrule/14.scss
@@ -1,0 +1,1 @@
+@apply --custom-property

--- a/test/scss/atrule/test.coffee
+++ b/test/scss/atrule/test.coffee
@@ -14,6 +14,7 @@ describe 'scss/atrule >>', ->
   it '11', -> this.shouldBeOk()
   it '12', -> this.shouldBeOk()
   it '13', -> this.shouldBeOk()
+  it '14', -> this.shouldBeOk()
 
   it 'c.0', -> this.shouldBeOk()
   it 'c.1', -> this.shouldBeOk()

--- a/test/scss/ruleset/9.json
+++ b/test/scss/ruleset/9.json
@@ -1,0 +1,336 @@
+{
+  "type": "ruleset",
+  "content": [
+    {
+      "type": "selector",
+      "content": [
+        {
+          "type": "pseudoClass",
+          "content": [
+            {
+              "type": "ident",
+              "content": "root",
+              "syntax": "scss",
+              "start": {
+                "line": 1,
+                "column": 2
+              },
+              "end": {
+                "line": 1,
+                "column": 5
+              }
+            }
+          ],
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 1
+          },
+          "end": {
+            "line": 1,
+            "column": 5
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 1
+      },
+      "end": {
+        "line": 1,
+        "column": 5
+      }
+    },
+    {
+      "type": "space",
+      "content": " ",
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 6
+      },
+      "end": {
+        "line": 1,
+        "column": 6
+      }
+    },
+    {
+      "type": "block",
+      "content": [
+        {
+          "type": "space",
+          "content": "\n  ",
+          "syntax": "scss",
+          "start": {
+            "line": 1,
+            "column": 8
+          },
+          "end": {
+            "line": 2,
+            "column": 2
+          }
+        },
+        {
+          "type": "declaration",
+          "content": [
+            {
+              "type": "customProperty",
+              "content": [
+                {
+                  "type": "ident",
+                  "content": "foo-bar",
+                  "syntax": "scss",
+                  "start": {
+                    "line": 2,
+                    "column": 5
+                  },
+                  "end": {
+                    "line": 2,
+                    "column": 11
+                  }
+                }
+              ],
+              "syntax": "scss",
+              "start": {
+                "line": 2,
+                "column": 3
+              },
+              "end": {
+                "line": 2,
+                "column": 11
+              }
+            },
+            {
+              "type": "propertyDelimiter",
+              "content": ":",
+              "syntax": "scss",
+              "start": {
+                "line": 2,
+                "column": 12
+              },
+              "end": {
+                "line": 2,
+                "column": 12
+              }
+            },
+            {
+              "type": "space",
+              "content": " ",
+              "syntax": "scss",
+              "start": {
+                "line": 2,
+                "column": 13
+              },
+              "end": {
+                "line": 2,
+                "column": 13
+              }
+            },
+            {
+              "type": "value",
+              "content": [
+                {
+                  "type": "block",
+                  "content": [
+                    {
+                      "type": "space",
+                      "content": "\n    ",
+                      "syntax": "scss",
+                      "start": {
+                        "line": 2,
+                        "column": 15
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 4
+                      }
+                    },
+                    {
+                      "type": "declaration",
+                      "content": [
+                        {
+                          "type": "property",
+                          "content": [
+                            {
+                              "type": "ident",
+                              "content": "content",
+                              "syntax": "scss",
+                              "start": {
+                                "line": 3,
+                                "column": 5
+                              },
+                              "end": {
+                                "line": 3,
+                                "column": 11
+                              }
+                            }
+                          ],
+                          "syntax": "scss",
+                          "start": {
+                            "line": 3,
+                            "column": 5
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 11
+                          }
+                        },
+                        {
+                          "type": "propertyDelimiter",
+                          "content": ":",
+                          "syntax": "scss",
+                          "start": {
+                            "line": 3,
+                            "column": 12
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 12
+                          }
+                        },
+                        {
+                          "type": "space",
+                          "content": " ",
+                          "syntax": "scss",
+                          "start": {
+                            "line": 3,
+                            "column": 13
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 13
+                          }
+                        },
+                        {
+                          "type": "value",
+                          "content": [
+                            {
+                              "type": "string",
+                              "content": "'foobar'",
+                              "syntax": "scss",
+                              "start": {
+                                "line": 3,
+                                "column": 14
+                              },
+                              "end": {
+                                "line": 3,
+                                "column": 21
+                              }
+                            }
+                          ],
+                          "syntax": "scss",
+                          "start": {
+                            "line": 3,
+                            "column": 14
+                          },
+                          "end": {
+                            "line": 3,
+                            "column": 21
+                          }
+                        }
+                      ],
+                      "syntax": "scss",
+                      "start": {
+                        "line": 3,
+                        "column": 5
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 21
+                      }
+                    },
+                    {
+                      "type": "declarationDelimiter",
+                      "content": ";",
+                      "syntax": "scss",
+                      "start": {
+                        "line": 3,
+                        "column": 22
+                      },
+                      "end": {
+                        "line": 3,
+                        "column": 22
+                      }
+                    },
+                    {
+                      "type": "space",
+                      "content": "\n  ",
+                      "syntax": "scss",
+                      "start": {
+                        "line": 3,
+                        "column": 23
+                      },
+                      "end": {
+                        "line": 4,
+                        "column": 2
+                      }
+                    }
+                  ],
+                  "syntax": "scss",
+                  "start": {
+                    "line": 2,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 4,
+                    "column": 3
+                  }
+                }
+              ],
+              "syntax": "scss",
+              "start": {
+                "line": 2,
+                "column": 14
+              },
+              "end": {
+                "line": 4,
+                "column": 3
+              }
+            }
+          ],
+          "syntax": "scss",
+          "start": {
+            "line": 2,
+            "column": 3
+          },
+          "end": {
+            "line": 4,
+            "column": 3
+          }
+        },
+        {
+          "type": "space",
+          "content": "\n",
+          "syntax": "scss",
+          "start": {
+            "line": 4,
+            "column": 4
+          },
+          "end": {
+            "line": 4,
+            "column": 4
+          }
+        }
+      ],
+      "syntax": "scss",
+      "start": {
+        "line": 1,
+        "column": 7
+      },
+      "end": {
+        "line": 5,
+        "column": 1
+      }
+    }
+  ],
+  "syntax": "scss",
+  "start": {
+    "line": 1,
+    "column": 1
+  },
+  "end": {
+    "line": 5,
+    "column": 1
+  }
+}

--- a/test/scss/ruleset/9.scss
+++ b/test/scss/ruleset/9.scss
@@ -1,0 +1,5 @@
+:root {
+  --foo-bar: {
+    content: 'foobar';
+  }
+}

--- a/test/scss/ruleset/test.coffee
+++ b/test/scss/ruleset/test.coffee
@@ -9,6 +9,7 @@ describe 'scss/ruleset >>', ->
   it '6', -> this.shouldBeOk()
   it '7', -> this.shouldBeOk()
   it '8', -> this.shouldBeOk()
+  it '9', -> this.shouldBeOk()
 
   it 'c.0', -> this.shouldBeOk()
   it 'c.1', -> this.shouldBeOk()


### PR DESCRIPTION
Adds support for `@apply` at-rule http://tabatkins.github.io/specs/css-apply-rule/#defining 

```sass
:root {
  --toolbar-theme: {
    background-color: hsl(120, 70%, 95%);
    border-radius: 4px;
    border: 1px solid var(--theme-color late);
  };
  --toolbar-title-theme: {
    color: green;
  };
}

.toolbar {
  @apply --toolbar-theme;
}
.toolbar > .title {
  @apply --toolbar-title-theme;
}
```

Closes https://github.com/tonyganch/gonzales-pe/issues/197
Closes https://github.com/tonyganch/gonzales-pe/issues/260